### PR TITLE
[Feat] 마이페이지 유저 정보 조회

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/api/insight/InsightController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/api/insight/InsightController.java
@@ -3,6 +3,7 @@ package ccc.keeweapi.api.insight;
 import ccc.keeweapi.dto.ApiResponse;
 import ccc.keeweapi.dto.insight.*;
 import ccc.keeweapi.service.insight.InsightApiService;
+import ccc.keewecore.consts.KeeweConsts;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -55,5 +56,15 @@ public class InsightController {
     @GetMapping("/{insightId}/challenge-record")
     public ApiResponse<ChallengeRecordResponse> getChallengeRecord(@PathVariable Long insightId) {
         return ApiResponse.ok(insightApiService.getChallengeRecord(insightId));
+    }
+
+    @GetMapping("/my-page/{userId}")
+    public ApiResponse<List<InsightMyPageResponse>> getInsightForMyPage(
+            @PathVariable Long userId,
+            @RequestParam(required = false) Long drawerId,
+            @RequestParam(required = false, defaultValue = KeeweConsts.LONG_MAX_STRING) Long cursor,
+            @RequestParam Long limit) {
+
+        return ApiResponse.ok(insightApiService.getInsightsForMyPage(userId, drawerId, CursorPageable.of(cursor, limit)));
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/api/user/ProfileController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/api/user/ProfileController.java
@@ -2,6 +2,7 @@ package ccc.keeweapi.api.user;
 
 import ccc.keeweapi.dto.ApiResponse;
 import ccc.keeweapi.dto.user.FollowToggleResponse;
+import ccc.keeweapi.dto.user.ProfileMyPageResponse;
 import ccc.keeweapi.dto.user.OnboardRequest;
 import ccc.keeweapi.dto.user.OnboardResponse;
 import ccc.keeweapi.service.user.ProfileApiService;
@@ -24,5 +25,10 @@ public class ProfileController {
     @PostMapping("/follow/{targetId}")
     public ApiResponse<FollowToggleResponse> toggleFollowership(@PathVariable Long targetId) {
         return ApiResponse.ok(profileApiService.toggleFollowership(targetId));
+    }
+
+    @GetMapping("/{targetId}")
+    public ApiResponse<ProfileMyPageResponse> getMyPageProfile(@PathVariable Long targetId) {
+        return ApiResponse.ok(profileApiService.getMyPageProfile(targetId));
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
@@ -131,6 +131,17 @@ public class InsightAssembler {
         return ChallengeRecordResponse.of(challenge.getId(), challenge.getName(), null, null);
     }
 
+    public InsightMyPageResponse toInsightMyPageResponse(InsightMyPageDto dto) {
+        return InsightMyPageResponse.of(
+                dto.getId(),
+                dto.getContents(),
+                dto.getLink(),
+                toReactionAggregationResponse(dto.getReaction()),
+                dto.getCreatedAt(),
+                dto.isBookmark()
+        );
+    }
+
     private boolean isAuthor(Insight insight) {
         return insight.getWriter().getId() == SecurityUtil.getUserId();
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
@@ -137,7 +137,7 @@ public class InsightAssembler {
                 dto.getContents(),
                 dto.getLink(),
                 toReactionAggregationResponse(dto.getReaction()),
-                dto.getCreatedAt(),
+                dto.getCreatedAt().toString(),
                 dto.isBookmark()
         );
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
@@ -3,12 +3,16 @@ package ccc.keeweapi.component;
 import ccc.keeweapi.dto.user.FollowToggleResponse;
 import ccc.keeweapi.dto.user.OnboardRequest;
 import ccc.keeweapi.dto.user.OnboardResponse;
+import ccc.keeweapi.dto.user.ProfileMyPageResponse;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.dto.user.FollowCheckDto;
 import ccc.keewedomain.dto.user.FollowToggleDto;
-import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.dto.user.OnboardDto;
+import ccc.keewedomain.persistence.domain.common.Interest;
+import ccc.keewedomain.persistence.domain.user.User;
 import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
 
 @Component
 public class ProfileAssembler {
@@ -31,5 +35,22 @@ public class ProfileAssembler {
 
     public FollowCheckDto toFollowCheckDto(Long targetId) {
         return FollowCheckDto.of(targetId, SecurityUtil.getUserId());
+    }
+
+    //TODO 프로필 사진, 타이틀, 자기소개 수정
+    public ProfileMyPageResponse toProfileMyPageResponse(User user, Boolean isFollowing, Long followerCount, Long followingCount, String challengeName) {
+        return ProfileMyPageResponse.of(
+                user.getNickname(),
+                "image",
+                "title",
+                "introduction",
+                user.getInterests().stream()
+                        .map(Interest::getName)
+                        .collect(Collectors.toList()),
+                isFollowing,
+                followerCount,
+                followingCount,
+                challengeName
+        );
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/config/security/SecurityConfig.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ import static org.springframework.http.HttpMethod.GET;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final String[] SWAGGER_URL = {"/", "/docs/openapi3.yaml", "/favicon.ico"};
-    private final String SIGNUP_URL = "/api/v1/user/**";
+    private final String SIGNUP_URL = "/api/v1/user/*";
     private final String HEALTH_CHECK_URL = "/api/health-check";
 
     private final UserDetailsService userService;

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/insight/InsightMyPageResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/insight/InsightMyPageResponse.java
@@ -4,8 +4,6 @@ import ccc.keewedomain.persistence.domain.common.Link;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
 @Getter
 @AllArgsConstructor(staticName = "of")
 public class InsightMyPageResponse {
@@ -13,6 +11,6 @@ public class InsightMyPageResponse {
     private String contents;
     private Link link;
     private ReactionAggregationResponse reaction;
-    private LocalDateTime createdAt;
+    private String createdAt;
     private boolean isBookmark;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/insight/InsightMyPageResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/insight/InsightMyPageResponse.java
@@ -1,0 +1,18 @@
+package ccc.keeweapi.dto.insight;
+
+import ccc.keewedomain.persistence.domain.common.Link;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class InsightMyPageResponse {
+    private Long id;
+    private String contents;
+    private Link link;
+    private ReactionAggregationResponse reaction;
+    private LocalDateTime createdAt;
+    private boolean isBookmark;
+}

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
@@ -1,0 +1,21 @@
+package ccc.keeweapi.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(staticName = "of")
+@Getter
+public class ProfileMyPageResponse {
+
+    private String nickname;
+    private String profilePhoto;
+    private String title;
+    private String introduction;
+    private List<String> interests;
+    private Boolean isFollow;
+    private Long followerCount;
+    private Long followingCount;
+    private String challengeName;
+}

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class ProfileMyPageResponse {
 
     private String nickname;
-    private String profilePhoto;
+    private String image;
     private String title;
     private String introduction;
     private List<String> interests;

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/InsightApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/InsightApiService.java
@@ -84,7 +84,7 @@ public class InsightApiService {
 
     @Transactional(readOnly = true)
     public List<InsightMyPageResponse> getInsightsForMyPage(Long userId, Long drawerId, CursorPageable<Long> cPage) {
-        return insightDomainService.getByUserId(SecurityUtil.getUser(), userId, drawerId, cPage).stream()
+        return insightDomainService.getInsightsForMyPage(SecurityUtil.getUser(), userId, drawerId, cPage).stream()
                 .map(insightAssembler::toInsightMyPageResponse)
                 .collect(Collectors.toList());
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/InsightApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/InsightApiService.java
@@ -81,4 +81,11 @@ public class InsightApiService {
 
         return insightAssembler.toChallengeRecordResponse(participation.getChallenge());
     }
+
+    @Transactional(readOnly = true)
+    public List<InsightMyPageResponse> getInsightsForMyPage(Long userId, Long drawerId, CursorPageable<Long> cPage) {
+        return insightDomainService.getByUserId(SecurityUtil.getUser(), userId, drawerId, cPage).stream()
+                .map(insightAssembler::toInsightMyPageResponse)
+                .collect(Collectors.toList());
+    }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
@@ -1,21 +1,27 @@
 package ccc.keeweapi.service.user;
 
+import ccc.keeweapi.component.ProfileAssembler;
 import ccc.keeweapi.dto.user.FollowToggleResponse;
 import ccc.keeweapi.dto.user.OnboardRequest;
 import ccc.keeweapi.dto.user.OnboardResponse;
-import ccc.keeweapi.component.ProfileAssembler;
+import ccc.keeweapi.dto.user.ProfileMyPageResponse;
+import ccc.keeweapi.utils.SecurityUtil;
+import ccc.keewedomain.dto.user.FollowCheckDto;
 import ccc.keewedomain.persistence.domain.user.User;
+import ccc.keewedomain.service.challenge.ChallengeDomainService;
 import ccc.keewedomain.service.user.ProfileDomainService;
+import ccc.keewedomain.service.user.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileApiService {
 
     private final ProfileDomainService profileDomainService;
+    private final UserDomainService userDomainService;
+    private final ChallengeDomainService challengeDomainService;
     private final ProfileAssembler profileAssembler;
 
     @Transactional
@@ -28,5 +34,20 @@ public class ProfileApiService {
     public FollowToggleResponse toggleFollowership(Long targetId) {
         boolean following = profileDomainService.toggleFollowership(profileAssembler.toFollowToggleDto(targetId));
         return profileAssembler.toFollowToggleResponse(following);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileMyPageResponse getMyPageProfile(Long targetId) {
+        User targetUser = userDomainService.getUserByIdWithInterests(targetId);
+        Long userId = SecurityUtil.getUserId();
+
+        boolean isFollowing = profileDomainService.isFollowing(FollowCheckDto.of(targetId, userId));
+        Long followerCount = profileDomainService.getFollowerCount(targetUser);
+        Long followingCount = profileDomainService.getFollowingCount(targetUser);
+        String challengeName = challengeDomainService.findCurrentParticipationWithChallenge(targetId)
+                .map(challengeParticipation -> challengeParticipation.getChallenge().getName())
+                .orElse(null);
+
+        return profileAssembler.toProfileMyPageResponse(targetUser, isFollowing, followerCount, followingCount, challengeName);
     }
 }

--- a/keewe-api/src/test/java/ccc/keeweapi/api/user/ProfileControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/api/user/ProfileControllerTest.java
@@ -3,6 +3,7 @@ package ccc.keeweapi.api.user;
 import ccc.keeweapi.document.utils.ApiDocumentationTest;
 import ccc.keeweapi.dto.user.FollowToggleResponse;
 import ccc.keeweapi.dto.user.OnboardResponse;
+import ccc.keeweapi.dto.user.ProfileMyPageResponse;
 import ccc.keeweapi.service.user.ProfileApiService;
 import ccc.keewedomain.persistence.domain.common.Interest;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -21,12 +22,12 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -110,6 +111,54 @@ public class ProfileControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("code").description("결과 코드"),
                                 fieldWithPath("data.following").description("팔로잉 토글 결과 (true: 팔로잉 상태, false: 언팔로잉 상태)"))
                         .tag("Profile")
+                        .build()
+        )));
+    }
+
+    @Test
+    @DisplayName("마이페이지 프로필 조회 테스트")
+    void my_page_profile() throws Exception {
+        when(profileApiService.getMyPageProfile(anyLong())).thenReturn(
+                ProfileMyPageResponse.of(
+                        "닉네임",
+                        "www.api-keewe.com/images/128398681",
+                        "대표 타이틀",
+                        "안녕하세요. 키위입니다.",
+                        List.of("개발", "백엔드", "프론트엔드"),
+                        false,
+                        342L,
+                        55231L,
+                        "출근하기"
+                )
+        );
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/user/profile/{targetId}", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        resultActions.andDo(restDocs.document(resource(
+                ResourceSnippetParameters.builder()
+                        .description("팔로잉 API 입니다.")
+                        .summary("유저 팔로잉 API")
+                        .pathParameters(
+                            parameterWithName("targetId").description("대상 유저의 ID")
+                        )
+                        .requestHeaders(
+                                headerWithName("Authorization").description("유저의 JWT"))
+                        .responseFields(
+                                fieldWithPath("message").description("요청 결과 메세지"),
+                                fieldWithPath("code").description("결과 코드"),
+                                fieldWithPath("data.nickname").description("닉네임"),
+                                fieldWithPath("data.image").description("프로필 이미지 링크"),
+                                fieldWithPath("data.title").description("대표 타이틀"),
+                                fieldWithPath("data.introduction").description("자기소개"),
+                                fieldWithPath("data.interests[]").description("관심사 리스트"),
+                                fieldWithPath("data.isFollow").description("팔로잉 여부 (true: 팔로잉 상태, false: 언팔로잉 상태)"),
+                                fieldWithPath("data.followerCount").description("팔로워 수"),
+                                fieldWithPath("data.followingCount").description("팔로우 하는 수"),
+                                fieldWithPath("data.challengeName").description("진행중인 챌린지 이름"))
+                        .tag("MyPage")
                         .build()
         )));
     }

--- a/keewe-domain/src/main/java/ccc/keewedomain/dto/insight/InsightMyPageDto.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/dto/insight/InsightMyPageDto.java
@@ -1,0 +1,18 @@
+package ccc.keewedomain.dto.insight;
+
+import ccc.keewedomain.persistence.domain.common.Link;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class InsightMyPageDto {
+    private Long id;
+    private String contents;
+    private Link link;
+    private ReactionAggregationGetDto reaction;
+    private LocalDateTime createdAt;
+    private boolean isBookmark;
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/insight/Insight.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/insight/Insight.java
@@ -55,7 +55,7 @@ public class Insight extends BaseTimeEntity {
     @OneToMany(mappedBy = "insight", fetch = LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "drawer_id")
     private Drawer drawer;
 

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
@@ -108,4 +108,22 @@ public class InsightQueryRepository {
                         .and(insight.id.lt(insightId)))
                 .fetchFirst();
     }
+
+    public List<Insight> findByUserIdAndDrawerId(Long userId, Long drawerId, CursorPageable<Long> cPage) {
+        return queryFactory
+                .select(insight)
+                .from(insight)
+                .where(insight.writer.id.eq(userId)
+                        .and(insight.id.lt(cPage.getCursor()))
+                        .and(drawerIdEq(drawerId))
+                )
+                .orderBy(insight.id.desc())
+                .limit(cPage.getLimit())
+                .fetch();
+    }
+
+
+    private BooleanExpression drawerIdEq(Long drawerId) {
+        return drawerId != null ? insight.drawer.id.eq(drawerId) : null;
+    }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/FollowRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/FollowRepository.java
@@ -1,8 +1,11 @@
 package ccc.keewedomain.persistence.repository.user;
 
 import ccc.keewedomain.persistence.domain.user.Follow;
+import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.domain.user.id.FollowId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, FollowId> {
+    Long countByFollowee(User followee);
+    Long countByFollower(User follower);
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/UserQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/UserQueryRepository.java
@@ -1,0 +1,29 @@
+package ccc.keewedomain.persistence.repository.user;
+
+import ccc.keewedomain.persistence.domain.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static ccc.keewedomain.persistence.domain.common.QInterest.interest;
+import static ccc.keewedomain.persistence.domain.user.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<User> findByIdWithInterests(Long userId) {
+        return Optional.ofNullable(queryFactory
+                .select(user)
+                .from(user)
+                .leftJoin(user.interests, interest)
+                .fetchJoin()
+                .where(user.id.eq(userId)
+                        .and(user.deleted.isFalse()))
+                .fetchFirst());
+    }
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
@@ -177,7 +177,7 @@ public class InsightDomainService {
     }
 
     @Transactional(readOnly = true)
-    public List<InsightMyPageDto> getByUserId(User user, Long targetUserId, Long drawerId, CursorPageable<Long> cPage) {
+    public List<InsightMyPageDto> getInsightsForMyPage(User user, Long targetUserId, Long drawerId, CursorPageable<Long> cPage) {
         List<Insight> insights = insightQueryRepository.findByUserIdAndDrawerId(targetUserId, drawerId, cPage);
         Map<Long, Boolean> bookmarkPresenceMap = bookmarkQueryRepository.getBookmarkPresenceMap(user, insights);
         return insights.parallelStream()

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
@@ -34,7 +34,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -175,6 +174,22 @@ public class InsightDomainService {
     public Long getThisWeekCount(ChallengeParticipation participation, LocalDateTime endDate) {
         LocalDateTime startDate = endDate.minusWeeks(1);
         return insightQueryRepository.countByParticipationBetween(participation, startDate, endDate);
+    }
+
+    @Transactional(readOnly = true)
+    public List<InsightMyPageDto> getByUserId(User user, Long targetUserId, Long drawerId, CursorPageable<Long> cPage) {
+        List<Insight> insights = insightQueryRepository.findByUserIdAndDrawerId(targetUserId, drawerId, cPage);
+        Map<Long, Boolean> bookmarkPresenceMap = bookmarkQueryRepository.getBookmarkPresenceMap(user, insights);
+        return insights.parallelStream()
+                .map(insight -> InsightMyPageDto.of(
+                        insight.getId(),
+                        insight.getContents(),
+                        insight.getLink(),
+                        getReactionAggregation(insight.getId()),
+                        insight.getCreatedAt(),
+                        bookmarkPresenceMap.getOrDefault(insight.getId(), false)
+                ))
+                .collect(Collectors.toList());
     }
 
     /*****************************************************************

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/user/ProfileDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/user/ProfileDomainService.java
@@ -47,7 +47,7 @@ public class ProfileDomainService {
                                 }
                         );
 
-        return isFollowing(FollowCheckDto.of(target.getId(), user.getId()));
+        return isFollowing(FollowCheckDto.of(user.getId(), target.getId()));
     }
 
     public boolean isFollowing(FollowCheckDto followCheckDto) {

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/user/ProfileDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/user/ProfileDomainService.java
@@ -59,4 +59,12 @@ public class ProfileDomainService {
             throw new KeeweException(KeeweRtnConsts.ERR446);
         }
     }
+
+    public Long getFollowerCount(User user) {
+        return followRepository.countByFollowee(user);
+    }
+
+    public Long getFollowingCount(User user) {
+        return followRepository.countByFollower(user);
+    }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/user/UserDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/user/UserDomainService.java
@@ -5,6 +5,7 @@ import ccc.keewecore.exception.KeeweException;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.domain.user.enums.VendorType;
 import ccc.keewedomain.dto.user.UserSignUpDto;
+import ccc.keewedomain.persistence.repository.user.UserQueryRepository;
 import ccc.keewedomain.persistence.repository.user.UserRepository;
 import ccc.keeweinfra.dto.GoogleProfileResponse;
 import ccc.keeweinfra.dto.KakaoProfileResponse;
@@ -24,6 +25,7 @@ import java.util.Optional;
 @Slf4j
 public class UserDomainService {
     private final UserRepository userRepository;
+    private final UserQueryRepository userQueryRepository;
     private final KakaoInfraService kakaoInfraService;
     private final NaverInfraService naverInfraService;
     private final GoogleInfraService googleInfraService;
@@ -53,6 +55,10 @@ public class UserDomainService {
 
     public Optional<User> getUserByVendorIdAndVendorType(String vendorId, VendorType vendorType) {
         return userRepository.findByVendorIdAndVendorType(vendorId, vendorType);
+    }
+
+    public User getUserByIdWithInterests(Long id) {
+        return userQueryRepository.findByIdWithInterests(id).orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR411));
     }
 
     private KakaoProfileResponse getKakaoProfile(String code) {

--- a/scripts/batch_deploy.sh
+++ b/scripts/batch_deploy.sh
@@ -1,6 +1,6 @@
 JAR_DIR='/home/ubuntu/'$2
 
-cp keewe-batch/build/libs/keewe-batch-0.0.1-SNAPSHOT.jar ${JAR_DIR}/
+cp keewe-batch/build/libs/keewe-batch-0.0.1-SNAPSHOT.jar ${JAR_DIR}
 
 echo "> Auto batch deploy starting...."
 

--- a/scripts/batch_deploy.sh
+++ b/scripts/batch_deploy.sh
@@ -1,18 +1,21 @@
 JAR_DIR='/home/ubuntu/'$2
 
+cp keewe-batch/build/libs/keewe-batch-0.0.1-SNAPSHOT.jar ${JAR_DIR}/
+
 echo "> Auto batch deploy starting...."
 
-mkdir $JAR_DIR
+mkdir -p $JAR_DIR
 cd $JAR_DIR
 
-ORIGIN_JAR_PATH= "${JAR_DIR}/*.jar"
+chmod 770 ${JAR_DIR}/$1-0.0.1-SNAPSHOT.jar
+ORIGIN_JAR_PATH="${JAR_DIR}/$1-0.0.1-SNAPSHOT.jar"
 ORIGIN_JAR_NAME=$(basename ${ORIGIN_JAR_PATH})
 TARGET_PATH="${JAR_DIR}/batch-application.jar"
 
 echo "> Do deploy :: $1"
 echo "  > 배포 JAR: "${ORIGIN_JAR_NAME}
 
-echo "  > sudo ln -s -f ${JAR_DIR}${ORIGIN_JAR_NAME} ${TARGET_PATH}"
-sudo ln -s -f ${JAR_DIR}${ORIGIN_JAR_NAME} ${TARGET_PATH}
+echo "  > sudo ln -s -f ${JAR_DIR}/${ORIGIN_JAR_NAME} ${TARGET_PATH}"
+ln -s -f "${JAR_DIR}/${ORIGIN_JAR_NAME} ${TARGET_PATH}"
 
 echo "> Batch deploy Complete ! !"


### PR DESCRIPTION
1. 마이 페이지 유저 정보 조회
   - userId를 통한 마이 페이지 조회
   - 문서화용 테스트
2. SecurityConfig SIGNUP_URL 수정
   - ~/user/** -> ~/user/*로 수정
3. 팔로우 토글의 isFollowing 파라미터 id 순서 수정