### PR TITLE
[Feat] 타이틀 도메인 정의

### DIFF
--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
@@ -29,6 +29,6 @@ public class Title extends BaseTimeEntity {
     @Column(name = "introduction", nullable = false)
     private String introduction;
 
-    @Column(name = "image")
-    private String image;
+    @Column(name = "image_url")
+    private String imageURL;
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
@@ -1,0 +1,28 @@
+package ccc.keewedomain.persistence.domain.user;
+
+import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
+import ccc.keewedomain.persistence.domain.user.enums.TitleCategory;
+
+import javax.persistence.*;
+
+@Entity
+public class Title extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "title_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private TitleCategory category;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "introduction", nullable = false)
+    private String introduction;
+
+    @Column(name = "image")
+    private String image;
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
@@ -1,6 +1,5 @@
 package ccc.keewedomain.persistence.domain.user;
 
-import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
 import ccc.keewedomain.persistence.domain.user.enums.TitleCategory;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +11,7 @@ import javax.persistence.*;
 @Table(name = "title")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Title extends BaseTimeEntity {
+public class Title {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +27,4 @@ public class Title extends BaseTimeEntity {
 
     @Column(name = "introduction", nullable = false)
     private String introduction;
-
-    @Column(name = "image_url")
-    private String imageURL;
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/Title.java
@@ -2,10 +2,16 @@ package ccc.keewedomain.persistence.domain.user;
 
 import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
 import ccc.keewedomain.persistence.domain.user.enums.TitleCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Table(name = "title")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Title extends BaseTimeEntity {
 
     @Id

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/TitleAchievement.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/TitleAchievement.java
@@ -1,0 +1,29 @@
+package ccc.keewedomain.persistence.domain.user;
+
+import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
+import ccc.keewedomain.persistence.domain.user.id.TitleAchievementId;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "title_achievement")
+@IdClass(TitleAchievementId.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TitleAchievement extends BaseTimeEntity {
+
+    @Id
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Id
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "title_id")
+    private Title title;
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/TitleCategory.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/TitleCategory.java
@@ -3,7 +3,7 @@ package ccc.keewedomain.persistence.domain.user.enums;
 public enum TitleCategory {
     SIGNUP,
     INSIGHT,
-    FOLLOWER,
+    FOLLOW,
     REACTION,
     CHALLENGE,
     SHARE,

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/TitleCategory.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/TitleCategory.java
@@ -1,0 +1,13 @@
+package ccc.keewedomain.persistence.domain.user.enums;
+
+public enum TitleCategory {
+    SIGNUP,
+    INSIGHT,
+    FOLLOWER,
+    REACTION,
+    CHALLENGE,
+    SHARE,
+    BOOKMARK,
+    FRIEND_INVITATION,
+    KEEWE_TITLE
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/id/TitleAchievementId.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/id/TitleAchievementId.java
@@ -1,0 +1,16 @@
+package ccc.keewedomain.persistence.domain.user.id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TitleAchievementId implements Serializable {
+    private Long user;
+    private Long title;
+}

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -60,9 +60,6 @@ CREATE TABLE IF NOT EXISTS `title`
     category        VARCHAR(255)    NOT NULL,
     name            VARCHAR(255)    NOT NULL,
     introduction    VARCHAR(255)    NOT NULL,
-    image_url       VARCHAR(255)    NOT NULL,
-    created_at      DATETIME(6)     NOT NULL,
-    updated_at      DATETIME(6)     NOT NULL,
 
     PRIMARY KEY (title_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `title`
     category        VARCHAR(255)    NOT NULL,
     name            VARCHAR(255)    NOT NULL,
     introduction    VARCHAR(255)    NOT NULL,
-    image           VARCHAR(255)    NOT NULL,
+    image_url       VARCHAR(255)    NOT NULL,
     created_at      DATETIME(6)     NOT NULL,
     updated_at      DATETIME(6)     NOT NULL,
 

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -54,7 +54,18 @@ CREATE TABLE IF NOT EXISTS `favorite_interests`
     CONSTRAINT `favorite_activities_constraint` UNIQUE (user_id, interest_name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS `title`
+(
+    title_id        BIGINT          NOT NULL,
+    category        VARCHAR(255)    NOT NULL,
+    name            VARCHAR(255)    NOT NULL,
+    introduction    VARCHAR(255)    NOT NULL,
+    image           VARCHAR(255)    NOT NULL,
+    created_at      DATETIME(6)     NOT NULL,
+    updated_at      DATETIME(6)     NOT NULL,
 
+    PRIMARY KEY (title_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /**
   챌린지 관련 테이블 정의
  */

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -66,6 +66,19 @@ CREATE TABLE IF NOT EXISTS `title`
 
     PRIMARY KEY (title_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `title_achievement`
+(
+    user_id         BIGINT          NOT NULL,
+    title_id        BIGINT          NOT NULL,
+    created_at      DATETIME(6)     NOT NULL,
+    updated_at      DATETIME(6)     NOT NULL,
+
+    PRIMARY KEY (user_id, title_id),
+    FOREIGN KEY (user_id) REFERENCES `user`(user_id),
+    FOREIGN KEY (title_id) REFERENCES `title`(title_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 /**
   챌린지 관련 테이블 정의
  */

--- a/keewe-domain/src/main/resources/dml/issue-171_dml.sql
+++ b/keewe-domain/src/main/resources/dml/issue-171_dml.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `title`
     category        VARCHAR(255)    NOT NULL,
     name            VARCHAR(255)    NOT NULL,
     introduction    VARCHAR(255)    NOT NULL,
-    image           VARCHAR(255)    NOT NULL,
+    image_url       VARCHAR(255)    NOT NULL,
     created_at      DATETIME(6)     NOT NULL,
     updated_at      DATETIME(6)     NOT NULL,
 

--- a/keewe-domain/src/main/resources/dml/issue-171_dml.sql
+++ b/keewe-domain/src/main/resources/dml/issue-171_dml.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS `title`
+(
+    title_id        BIGINT          NOT NULL,
+    category        VARCHAR(255)    NOT NULL,
+    name            VARCHAR(255)    NOT NULL,
+    introduction    VARCHAR(255)    NOT NULL,
+    image           VARCHAR(255)    NOT NULL,
+    created_at      DATETIME(6)     NOT NULL,
+    updated_at      DATETIME(6)     NOT NULL,
+
+    PRIMARY KEY (title_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `title_achievement`
+(
+    user_id         BIGINT          NOT NULL,
+    title_id        BIGINT          NOT NULL,
+    created_at      DATETIME(6)     NOT NULL,
+    updated_at      DATETIME(6)     NOT NULL,
+
+    PRIMARY KEY (user_id, title_id),
+    FOREIGN KEY (user_id) REFERENCES `user`(user_id),
+    FOREIGN KEY (title_id) REFERENCES `title`(title_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/keewe-domain/src/main/resources/dml/issue-171_dml.sql
+++ b/keewe-domain/src/main/resources/dml/issue-171_dml.sql
@@ -4,9 +4,6 @@ CREATE TABLE IF NOT EXISTS `title`
     category        VARCHAR(255)    NOT NULL,
     name            VARCHAR(255)    NOT NULL,
     introduction    VARCHAR(255)    NOT NULL,
-    image_url       VARCHAR(255)    NOT NULL,
-    created_at      DATETIME(6)     NOT NULL,
-    updated_at      DATETIME(6)     NOT NULL,
 
     PRIMARY KEY (title_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/keewe-domain/src/main/resources/dml/title_dml.sql
+++ b/keewe-domain/src/main/resources/dml/title_dml.sql
@@ -1,5 +1,88 @@
-REPLACE INTO title (title_id, category, name, introduction, image, created_at, updated_at)
-VALUES (1, 'SIGNUP', '시작이 반', '회원가입 시',
-        'https://keewe-image-bucket-for-local.s3.ap-northeast-2.amazonaws.com/0cd821e4-9428-4cc4-998a-c331df16adfa-4369df33-07e8-4303-bec1-6577a379edd9-%EA%B9%80%EC%98%81%EA%B8%B0+%EB%AF%BC%EC%A6%9D+copy+(1).jpg',
-        NOW(),
-        NOW())
+# 회원가입 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (1000, 'SIGNUP', '시작이 반', '회원가입 시');
+
+
+# 인사이트 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2000, 'INSIGHT', '위대한 첫 도약', '첫 인사이트 업로드');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2001, 'INSIGHT', '초보 기록가', '인사이트 5개');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2002, 'INSIGHT', '중급 기록가', '인사이트 10개');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2003, 'INSIGHT', '고급 기록가', '인사이트 50개');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2004, 'INSIGHT', '인사이트의 신', '인사이트 100개');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (2005, 'INSIGHT', '혼자서도 잘 해요', '챌린지가 아닌 인사이트 3개');
+
+
+# 팔로워 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (3000, 'FOLLOWER', '두근두근 첫만남', '첫 팔로워');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (3001, 'FOLLOWER', '자타공인 인기인', '팔로워 10명');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (3002, 'FOLLOWER', '피리부는 사나이', '팔로워 100명');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (3003, 'FOLLOWER', '정이 많은', '팔로잉 40명');
+
+
+# 반응 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (4000, 'REACTION', '참 잘했어요', '첫 반응');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (4001, 'REACTION', '아낌없이 주는 나무', '게시글 50개에 반응 누를 시');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (4002, 'REACTION', '키위새들의 픽', '한 게시물에서 10명에게 반응 얻을 시');
+
+
+# 챌린지 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (5000, 'CHALLENGE', '챌린지 메이커', '첫 챌린지 생성');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (5001, 'CHALLENGE', '실패는 성공의 어머니', '첫 챌린지 실패');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (5002, 'CHALLENGE', '첫번째 완주', '첫 챌린지 성공');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (5003, 'CHALLENGE', '쉬지않고 도전하는', '두번째 챌린지');
+
+
+# 공유 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (6000, 'SHARE', '혼자 보기 아까운', '누적 공유 10번');
+
+
+# 북마크 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (7000, 'BOOKMARK', '인사이트 수집가', '첫 북마크 저장');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (7001, 'BOOKMARK', '간직하고 싶은 인사이트', '타인이 내 인사이트를 첫 북마크');
+
+
+# 친구 초대 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (8000, 'FRIEND_INVITATION', '함께하는 즐거움', '첫 친구 초대');
+
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (8001, 'FRIEND_INVITATION', '마당발', '친구 10명 초대');
+
+
+# 키위 타이틀 카테고리
+INSERT IGNORE INTO title (title_id, category, name, introduction)
+VALUES (8000, 'KEEWE_TITLE', 'Shall We Keewe?', '모든 타이틀 달성');

--- a/keewe-domain/src/main/resources/dml/title_dml.sql
+++ b/keewe-domain/src/main/resources/dml/title_dml.sql
@@ -1,9 +1,9 @@
-# 회원가입 카테고리
+-- 회원가입 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (1000, 'SIGNUP', '시작이 반', '회원가입 시');
 
 
-# 인사이트 카테고리
+-- 인사이트 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (2000, 'INSIGHT', '위대한 첫 도약', '첫 인사이트 업로드');
 
@@ -23,7 +23,7 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (2005, 'INSIGHT', '혼자서도 잘 해요', '챌린지가 아닌 인사이트 3개');
 
 
-# 팔로워 카테고리
+-- 팔로워 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (3000, 'FOLLOW', '두근두근 첫만남', '첫 팔로워');
 
@@ -37,7 +37,7 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (3003, 'FOLLOW', '정이 많은', '팔로잉 40명');
 
 
-# 반응 카테고리
+-- 반응 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (4000, 'REACTION', '참 잘했어요', '첫 반응');
 
@@ -48,7 +48,7 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (4002, 'REACTION', '키위새들의 픽', '한 게시물에서 10명에게 반응 얻을 시');
 
 
-# 챌린지 카테고리
+-- 챌린지 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (5000, 'CHALLENGE', '챌린지 메이커', '첫 챌린지 생성');
 
@@ -62,12 +62,12 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (5003, 'CHALLENGE', '쉬지않고 도전하는', '두번째 챌린지');
 
 
-# 공유 카테고리
+-- 공유 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (6000, 'SHARE', '혼자 보기 아까운', '누적 공유 10번');
 
 
-# 북마크 카테고리
+-- 북마크 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (7000, 'BOOKMARK', '인사이트 수집가', '첫 북마크 저장');
 
@@ -75,7 +75,7 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (7001, 'BOOKMARK', '간직하고 싶은 인사이트', '타인이 내 인사이트를 첫 북마크');
 
 
-# 친구 초대 카테고리
+-- 친구 초대 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (8000, 'FRIEND_INVITATION', '함께하는 즐거움', '첫 친구 초대');
 
@@ -83,6 +83,6 @@ INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (8001, 'FRIEND_INVITATION', '마당발', '친구 10명 초대');
 
 
-# 키위 타이틀 카테고리
+-- 키위 타이틀 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
 VALUES (9000, 'KEEWE_TITLE', 'Shall We Keewe?', '모든 타이틀 달성');

--- a/keewe-domain/src/main/resources/dml/title_dml.sql
+++ b/keewe-domain/src/main/resources/dml/title_dml.sql
@@ -85,4 +85,4 @@ VALUES (8001, 'FRIEND_INVITATION', '마당발', '친구 10명 초대');
 
 # 키위 타이틀 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
-VALUES (8000, 'KEEWE_TITLE', 'Shall We Keewe?', '모든 타이틀 달성');
+VALUES (9000, 'KEEWE_TITLE', 'Shall We Keewe?', '모든 타이틀 달성');

--- a/keewe-domain/src/main/resources/dml/title_dml.sql
+++ b/keewe-domain/src/main/resources/dml/title_dml.sql
@@ -25,16 +25,16 @@ VALUES (2005, 'INSIGHT', '혼자서도 잘 해요', '챌린지가 아닌 인사�
 
 # 팔로워 카테고리
 INSERT IGNORE INTO title (title_id, category, name, introduction)
-VALUES (3000, 'FOLLOWER', '두근두근 첫만남', '첫 팔로워');
+VALUES (3000, 'FOLLOW', '두근두근 첫만남', '첫 팔로워');
 
 INSERT IGNORE INTO title (title_id, category, name, introduction)
-VALUES (3001, 'FOLLOWER', '자타공인 인기인', '팔로워 10명');
+VALUES (3001, 'FOLLOW', '자타공인 인기인', '팔로워 10명');
 
 INSERT IGNORE INTO title (title_id, category, name, introduction)
-VALUES (3002, 'FOLLOWER', '피리부는 사나이', '팔로워 100명');
+VALUES (3002, 'FOLLOW', '피리부는 사나이', '팔로워 100명');
 
 INSERT IGNORE INTO title (title_id, category, name, introduction)
-VALUES (3003, 'FOLLOWER', '정이 많은', '팔로잉 40명');
+VALUES (3003, 'FOLLOW', '정이 많은', '팔로잉 40명');
 
 
 # 반응 카테고리

--- a/keewe-domain/src/main/resources/dml/title_dml.sql
+++ b/keewe-domain/src/main/resources/dml/title_dml.sql
@@ -1,0 +1,5 @@
+REPLACE INTO title (title_id, category, name, introduction, image, created_at, updated_at)
+VALUES (1, 'SIGNUP', '시작이 반', '회원가입 시',
+        'https://keewe-image-bucket-for-local.s3.ap-northeast-2.amazonaws.com/0cd821e4-9428-4cc4-998a-c331df16adfa-4369df33-07e8-4303-bec1-6577a379edd9-%EA%B9%80%EC%98%81%EA%B8%B0+%EB%AF%BC%EC%A6%9D+copy+(1).jpg',
+        NOW(),
+        NOW())


### PR DESCRIPTION
1. Title 엔티티, DDL 작성
2. TitleAchievement 엔티티, DDL 작성
3. 이슈 관련 DML 작성

하고 나서 보니까 Title을 Enum으로 하는 방법도 가능할 것 같네요. 이 경우 장단점은

장점
- Title 테이블을 사용하지 않아도 됨.
- 특정 유저의 타이틀을 모두 조회하는 경우 편리

단점
- 새로운 타이틀을 추가하려면 api 서버 재시작 필요.
- image URL은 어떻게 설정할지 고민 필요.

의견 있으면 말씀해주세요 ㅎㅎ