### PR TITLE
[Feat] 유저 대표 타이틀 추가

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/CommentAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/CommentAssembler.java
@@ -50,8 +50,11 @@ public class CommentAssembler {
     }
 
     public CommentWriterResponse toCommentWriterResponse(User writer) {
-        //TODO 타이틀, 사진 정해지면 변경
-        return CommentWriterResponse.of(writer.getId(), writer.getNickname(), "title", "www.api-keewe.com/images");
+        return CommentWriterResponse.of(
+                writer.getId(),
+                writer.getNickname(),
+                writer.getRepTitleName(),
+                writer.getProfilePhotoURL());
     }
 
     public ReplyResponse toReplyResponse(Comment reply) {

--- a/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/InsightAssembler.java
@@ -105,9 +105,9 @@ public class InsightAssembler {
         return InsightAuthorAreaResponse.of(
                 insight.getId(),
                 writer.getNickname(),
-                "title",
+                writer.getRepTitleName(),
                 writer.getInterests(),
-                "www.api-keewe.com/images",
+                writer.getProfilePhotoURL(),
                 isAuthor(insight),
                 isFollowing,
                 insight.getCreatedAt().toString()

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
@@ -50,12 +50,12 @@ public class ProfileAssembler {
         );
     }
 
-    //TODO 프로필 사진, 타이틀, 자기소개 수정
+    //TODO 프로필 사진, 자기소개 수정
     public ProfileMyPageResponse toProfileMyPageResponse(User user, Boolean isFollowing, Long followerCount, Long followingCount, String challengeName) {
         return ProfileMyPageResponse.of(
                 user.getNickname(),
-                "image",
-                "title",
+                user.getProfilePhotoURL(),
+                user.getRepTitleName(),
                 "introduction",
                 user.getInterests().stream()
                         .map(Interest::getName)
@@ -85,13 +85,12 @@ public class ProfileAssembler {
         );
     }
 
-    //TODO 대표 타이틀 수정
     public FollowUserResponse toFollowerResponse(User follower, boolean isFollow) {
         return FollowUserResponse.of(
                 follower.getId(),
                 follower.getNickname(),
                 follower.getProfilePhotoURL(),
-                "아 타이틀..",
+                follower.getRepTitleName(),
                 isFollow);
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/user/ProfileController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/user/ProfileController.java
@@ -53,7 +53,7 @@ public class ProfileController {
     @GetMapping("/follower/{userId}")
     public ApiResponse<FollowUserListResponse> getFollowers(
             @PathVariable Long userId,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
             @RequestParam Long limit) {
         CursorPageable<LocalDateTime> cPage = CursorPageable.of(cursor, limit);
         return ApiResponse.ok(profileApiService.getFollowers(userId, cPage));

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/User.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/User.java
@@ -4,6 +4,7 @@ import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.exception.KeeweException;
 import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
 import ccc.keewedomain.persistence.domain.common.Interest;
+import ccc.keewedomain.persistence.domain.title.Title;
 import ccc.keewedomain.persistence.domain.user.enums.Privacy;
 import ccc.keewedomain.persistence.domain.user.enums.UserStatus;
 import ccc.keewedomain.persistence.domain.user.enums.VendorType;
@@ -74,6 +75,10 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "followee", fetch = LAZY)
     private List<Follow> followees = new ArrayList<>(); // 나를 팔로우하는 사람들
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "rep_title_id")
+    private Title repTitle;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/User.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/User.java
@@ -121,5 +121,9 @@ public class User extends BaseTimeEntity {
         }
         return "";
     }
+
+    public String getRepTitleName() {
+        return repTitle == null ? "" : repTitle.getName();
+    }
 }
 

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/CommentQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/CommentQueryRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static ccc.keewedomain.persistence.domain.insight.QComment.comment;
+import static ccc.keewedomain.persistence.domain.title.QTitle.title;
 import static ccc.keewedomain.persistence.domain.user.QUser.user;
 
 @Repository
@@ -29,6 +30,8 @@ public class CommentQueryRepository {
                 .from(comment)
                 .innerJoin(comment.writer, user)
                 .fetchJoin()
+                .leftJoin(user.repTitle, title)
+                .fetchJoin()
                 .where(comment.id.in(findIdByInsightIdAndCursorDesc(insightId, cPage)))
                 .orderBy(comment.id.desc())
                 .fetch();
@@ -40,7 +43,9 @@ public class CommentQueryRepository {
         return queryFactory
                 .select(comment)
                 .from(comment)
-                .leftJoin(comment.writer, user)
+                .innerJoin(comment.writer, user)
+                .fetchJoin()
+                .leftJoin(user.repTitle, title)
                 .fetchJoin()
                 .where(comment.id.in(parentIdsReplyDesc(insightId)))
                 .limit(limit)
@@ -73,6 +78,8 @@ public class CommentQueryRepository {
                 .from(comment)
                 .innerJoin(comment.writer, user)
                 .fetchJoin()
+                .leftJoin(user.repTitle, title)
+                .fetchJoin()
                 .where(comment.id.in(findFirstReplyIds(parents)))
                 .transform(GroupBy.groupBy(comment.parent.id).as(comment));
     }
@@ -83,6 +90,8 @@ public class CommentQueryRepository {
                 .select(comment)
                 .from(comment)
                 .innerJoin(comment.writer, user)
+                .fetchJoin()
+                .leftJoin(user.repTitle, title)
                 .fetchJoin()
                 .where(comment.id.in(findIdByParentIdAndCursorDesc(parentId, cPage)))
                 .orderBy(comment.id.desc())

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/UserQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/user/UserQueryRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static ccc.keewedomain.persistence.domain.common.QInterest.interest;
+import static ccc.keewedomain.persistence.domain.title.QTitle.title;
 import static ccc.keewedomain.persistence.domain.user.QFollow.follow;
 import static ccc.keewedomain.persistence.domain.user.QUser.user;
 
@@ -40,6 +41,8 @@ public class UserQueryRepository {
                 .from(follow)
                 .innerJoin(follow.follower, user)
                 .fetchJoin()
+                .leftJoin(user.repTitle, title)
+                .fetchJoin()
                 .where(follow.follower.id.in(findFollowerIdsOrderByCreatedAtDesc(target, cPage)),
                         follow.followee.eq(target))
                 .fetch();
@@ -50,6 +53,8 @@ public class UserQueryRepository {
                 .select(follow)
                 .from(follow)
                 .innerJoin(follow.followee, user)
+                .fetchJoin()
+                .leftJoin(user.repTitle, title)
                 .fetchJoin()
                 .where(follow.followee.id.in(findFolloweeIdsOrderByCreatedAtDesc(target, cPage)),
                         follow.follower.eq(target))

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
@@ -92,8 +92,8 @@ public class InsightDomainService {
                     InsightWriterDto.of(
                             i.getWriter().getId(),
                             i.getWriter().getNickname(),
-                            "Dummy Title.",
-                            "Dummy Profile Photo Link."
+                            i.getWriter().getRepTitleName(),
+                            i.getWriter().getProfilePhotoURL()
                     )
             )
         ).collect(Collectors.toList());

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -24,12 +24,14 @@ CREATE TABLE IF NOT EXISTS `user`
     profile_photo_id    BIGINT(20),
     privacy             VARCHAR(20)     NOT NULL,
     status              VARCHAR(255),
+    rep_title_id        BIGINT,
     deleted             BIT             NOT NULL,
     created_at          DATETIME(6)     NOT NULL,
     updated_at          DATETIME(6)     NOT NULL,
 
     PRIMARY KEY(user_id),
     FOREIGN KEY (profile_photo_id) REFERENCES  `profile_photo`(profile_photo_id),
+    FOREIGN KEY (rep_title_id) REFERENCES `title`(title_id),
     CONSTRAINT `vendor_constraint` UNIQUE (`vendor_id`, `vendor_type`),
     INDEX  `vendor_index` (`vendor_id`, `vendor_type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -43,7 +45,8 @@ CREATE TABLE IF NOT EXISTS `follow`
 
     PRIMARY KEY (follower_id, followee_id),
     FOREIGN KEY (followee_id) REFERENCES `user`(user_id),
-    FOREIGN KEY (follower_id) REFERENCES `user`(user_id)
+    FOREIGN KEY (follower_id) REFERENCES `user`(user_id),
+    INDEX `created_at_index` (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `favorite_interests`

--- a/keewe-domain/src/main/resources/ddl/ddl.sql
+++ b/keewe-domain/src/main/resources/ddl/ddl.sql
@@ -198,7 +198,8 @@ CREATE TABLE IF NOT EXISTS `comment`
 
     PRIMARY KEY (comment_id),
     FOREIGN KEY (insight_id) REFERENCES `insight`(insight_id),
-    FOREIGN KEY (writer_id) REFERENCES `user`(user_id)
+    FOREIGN KEY (writer_id) REFERENCES `user`(user_id),
+    FOREIGN KEY (parent_comment_id) REFERENCES `comment`(comment_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `comment_like`

--- a/keewe-domain/src/main/resources/dml/issue-182_dml.sql
+++ b/keewe-domain/src/main/resources/dml/issue-182_dml.sql
@@ -1,3 +1,6 @@
 ALTER TABLE `user`
     ADD COLUMN rep_title_id BIGINT,
     ADD FOREIGN KEY (rep_title_id) REFERENCES `title`(title_id);
+
+ALTER TABLE keewe.`comment`
+    ADD CONSTRAINT FOREIGN KEY (parent_comment_id) REFERENCES `comment`(comment_id);

--- a/keewe-domain/src/main/resources/dml/issue-182_dml.sql
+++ b/keewe-domain/src/main/resources/dml/issue-182_dml.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `user`
+    ADD COLUMN rep_title_id BIGINT,
+    ADD FOREIGN KEY (rep_title_id) REFERENCES `title`(title_id);


### PR DESCRIPTION
1. 유저 엔티티에 대표 타이틀 추가
2. 대표 타이틀, 프로필 이미지 URL 임시 값 제거

수정 사항
1. 팔로워 목록 조회 컨트롤러 required false를 true로 변경(삭제)
2. 댓글 테이블 부모 댓글 외래키 제약 조건 추가


- close #182 