### PR TITLE
[Feat] 챌린지 기록 검사 배치 - 매일 진행현황 확인하도록 변경

### DIFF
--- a/keewe-batch/src/main/java/ccc/keewebatch/batch/ChallengeRecordCheckConfiguration.java
+++ b/keewe-batch/src/main/java/ccc/keewebatch/batch/ChallengeRecordCheckConfiguration.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.Temporal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -96,7 +95,7 @@ public class ChallengeRecordCheckConfiguration {
         LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MIN);
 
         return cp -> {
-            int remainDays = getRemainDays(endDate, cp.getCreatedAt());
+            int remainDays = getRemainDays(cp.getCreatedAt(), endDateTime);
             int insightPerWeek = cp.getInsightPerWeek();
             LocalDateTime startOfWeekDateTime = endDateTime.minusDays(7 - remainDays);
             Long thisWeekCount = insightDomainService.countInsightCreatedAtBetween(cp, startOfWeekDateTime, endDateTime);
@@ -116,11 +115,11 @@ public class ChallengeRecordCheckConfiguration {
         return remainInsightNumber == 0 && isSameWeek(endDateTime, cpEndDate);
     }
 
-    private boolean isSameWeek(Temporal startDate, Temporal endDate) {
+    private boolean isSameWeek(LocalDate startDate, LocalDate endDate) {
         return Duration.between(startDate, endDate).toDays() < 7;
     }
 
-    private int getRemainDays(LocalDate startDate, LocalDateTime endDateTime) {
-        return (7 - Math.abs(startDate.getDayOfWeek().getValue() - endDateTime.getDayOfWeek().getValue())) % 7;
+    private int getRemainDays(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return (7 - Math.abs(startDateTime.getDayOfWeek().getValue() - endDateTime.getDayOfWeek().getValue())) % 7;
     }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
@@ -169,8 +169,7 @@ public class InsightDomainService {
     }
 
     @Transactional(readOnly = true)
-    public Long getThisWeekCount(ChallengeParticipation participation, LocalDateTime endDate) {
-        LocalDateTime startDate = endDate.minusWeeks(1);
+    public Long countInsightCreatedAtBetween(ChallengeParticipation participation, LocalDateTime startDate, LocalDateTime endDate) {
         return insightQueryRepository.countByParticipationBetween(participation, startDate, endDate);
     }
 


### PR DESCRIPTION
1. 남은 일 수 < 남은 인사이트 개수인 경우 실패
2. 마지막 주 조건 달성시 종료일보다 빠르게 성공

- close #204 