### PR TITLE
[Feat] 챌린지 상세 함께 기록 조회 API, 챌린지 참가 중인 인원 조회 API

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -145,4 +145,8 @@ public class ChallengeAssembler {
                 current,
                 participation.getTotalInsightNumber());
     }
+
+    public ChallengerCountResponse toChallengerCountResponse(Long countParticipatingUser) {
+        return ChallengerCountResponse.of(countParticipatingUser);
+    }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -6,6 +6,7 @@ import ccc.keewedomain.dto.challenge.ChallengeCreateDto;
 import ccc.keewedomain.dto.challenge.ChallengeParticipateDto;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
+import ccc.keewedomain.persistence.domain.user.User;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -134,5 +135,14 @@ public class ChallengeAssembler {
                 challenge.getIntroduction(),
                 insightCount
         );
+    }
+
+    public TogetherChallengerResponse toTogetherChallengerResponse(ChallengeParticipation participation, Long current) {
+        User challenger = participation.getChallenger();
+        return TogetherChallengerResponse.of(
+                challenger.getNickname(),
+                challenger.getProfilePhotoURL(),
+                current,
+                participation.getTotalInsightNumber());
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
@@ -48,13 +48,12 @@ public class ProfileAssembler {
         );
     }
 
-    //TODO 프로필 사진, 자기소개 수정
     public ProfileMyPageResponse toProfileMyPageResponse(User user, Boolean isFollowing, Long followerCount, Long followingCount, String challengeName) {
         return ProfileMyPageResponse.of(
                 user.getNickname(),
                 user.getProfilePhotoURL(),
                 user.getRepTitleName(),
-                "introduction",
+                user.getIntroduction(),
                 user.getInterests().stream()
                         .map(Interest::getName)
                         .collect(Collectors.toList()),

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -42,12 +42,12 @@ public class ChallengeParticipationController {
         return ApiResponse.ok(challengeApiService.getWeekProgress());
     }
 
-    @GetMapping("/{challengeId}/challenger")
+    @GetMapping("/{challengeId}/challengers")
     public ApiResponse<List<TogetherChallengerResponse>> getTogetherChallengers(@PathVariable Long challengeId) {
         return ApiResponse.ok(challengeApiService.getTogetherChallengers(challengeId));
     }
 
-    @GetMapping("/{challengeId}/challenger/count")
+    @GetMapping("/{challengeId}/challengers/count")
     public ApiResponse<ChallengerCountResponse> getChallengerCount(@PathVariable Long challengeId) {
         return ApiResponse.ok(challengeApiService.getChallengerCount(challengeId));
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -46,4 +46,9 @@ public class ChallengeParticipationController {
     public ApiResponse<List<TogetherChallengerResponse>> getTogetherChallengers(@PathVariable Long challengeId) {
         return ApiResponse.ok(challengeApiService.getTogetherChallengers(challengeId));
     }
+
+    @GetMapping("/{challengeId}/challenger/count")
+    public ApiResponse<ChallengerCountResponse> getChallengerCount(@PathVariable Long challengeId) {
+        return ApiResponse.ok(challengeApiService.getChallengerCount(challengeId));
+    }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -1,21 +1,14 @@
 package ccc.keeweapi.controller.api.challenge;
 
 import ccc.keeweapi.dto.ApiResponse;
-import ccc.keeweapi.dto.challenge.ChallengeParticipateRequest;
-import ccc.keeweapi.dto.challenge.ChallengeParticipationResponse;
-import ccc.keeweapi.dto.challenge.InsightProgressResponse;
-import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
-import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
-import ccc.keeweapi.dto.challenge.WeekProgressResponse;
+import ccc.keeweapi.dto.challenge.*;
 import ccc.keeweapi.service.challenge.ChallengeApiService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/challenge")
@@ -47,5 +40,10 @@ public class ChallengeParticipationController {
     @GetMapping("/participation/my-week-progress")
     public ApiResponse<WeekProgressResponse> getMyThisWeekProgress() {
         return ApiResponse.ok(challengeApiService.getWeekProgress());
+    }
+
+    @GetMapping("/{challengeId}/challenger")
+    public ApiResponse<List<TogetherChallengerResponse>> getTogetherChallengers(@PathVariable Long challengeId) {
+        return ApiResponse.ok(challengeApiService.getTogetherChallengers(challengeId));
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengerCountResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengerCountResponse.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(staticName = "of")
 public class ChallengerCountResponse {
-    private Long challengerNumber;
+    private Long challengerCount;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengerCountResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengerCountResponse.java
@@ -1,0 +1,10 @@
+package ccc.keeweapi.dto.challenge;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ChallengerCountResponse {
+    private Long challengerNumber;
+}

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/TogetherChallengerResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/TogetherChallengerResponse.java
@@ -1,0 +1,13 @@
+package ccc.keeweapi.dto.challenge;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class TogetherChallengerResponse {
+    private String nickname;
+    private String imageURL;
+    private long current;
+    private long total;
+}

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/TogetherChallengerResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/TogetherChallengerResponse.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class TogetherChallengerResponse {
     private String nickname;
     private String imageURL;
-    private long current;
-    private long total;
+    private long currentRecord;
+    private long goalRecord;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -111,4 +111,19 @@ public class ChallengeApiService {
 
         return dates;
     }
+
+    @Transactional(readOnly = true)
+    public List<TogetherChallengerResponse> getTogetherChallengers(Long challengeId) {
+        User user = SecurityUtil.getUser();
+        Challenge challenge = challengeDomainService.getByIdOrElseThrow(challengeId);
+        List<ChallengeParticipation> participations = challengeDomainService.findTogetherChallengeParticipations(challenge, user);
+        Map<Long, Long> insightCountPerParticipation = insightDomainService.getInsightCountPerParticipation(participations);
+
+        return participations.stream()
+                .map(participation -> challengeAssembler.toTogetherChallengerResponse(
+                        participation,
+                        insightCountPerParticipation.getOrDefault(participation.getId(), 0L))
+                )
+                .collect(Collectors.toList());
+    }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -126,4 +126,10 @@ public class ChallengeApiService {
                 )
                 .collect(Collectors.toList());
     }
+
+    @Transactional(readOnly = true)
+    public ChallengerCountResponse getChallengerCount(Long challengeId) {
+        Challenge challenge = challengeDomainService.getByIdOrElseThrow(challengeId);
+        return challengeAssembler.toChallengerCountResponse(challengeDomainService.countParticipatingUser(challenge));
+    }
 }

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -1,8 +1,8 @@
 package ccc.keeweapi.controller.api.challenge;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -10,12 +10,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ccc.keeweapi.document.utils.ApiDocumentationTest;
-import ccc.keeweapi.dto.challenge.ChallengeParticipationResponse;
-import ccc.keeweapi.dto.challenge.DayProgressResponse;
-import ccc.keeweapi.dto.challenge.InsightProgressResponse;
-import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
-import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
-import ccc.keeweapi.dto.challenge.WeekProgressResponse;
+import ccc.keeweapi.dto.challenge.*;
 import ccc.keeweapi.service.challenge.ChallengeApiService;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.time.LocalDate;
@@ -29,6 +24,7 @@ import org.mockito.Mock;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
@@ -235,6 +231,44 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data.participatingUserNumber").description("도전(참가)중인 유저의 수"),
                                 fieldWithPath("data.interest").description("관심사"),
                                 fieldWithPath("data.startDate").description("챌린지에 참가한 날짜")
+                        )
+                        .tag("Challenge")
+                        .build()
+        )));
+    }
+
+    @Test
+    @DisplayName("챌린지 상세 함께 기록 조회 API")
+    void get_together() throws Exception {
+        List<TogetherChallengerResponse> response = List.of(
+                TogetherChallengerResponse.of("닉네임1", "이미지 URL1", 1L, 4L),
+                TogetherChallengerResponse.of("닉네임2", "이미지 URL2", 2L, 4L),
+                TogetherChallengerResponse.of("닉네임3", "이미지 URL3", 3L, 4L)
+        );
+
+        when(challengeApiService.getTogetherChallengers(anyLong())).thenReturn(response);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challenger", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        resultActions.andDo(restDocs.document(resource(
+                ResourceSnippetParameters.builder()
+                        .description("챌린지 상세 함께 기록 조회 API 입니다.")
+                        .summary("챌린지 상세 함께 기록 조회 API")
+                        .requestHeaders(
+                                headerWithName("Authorization").description("유저의 JWT")
+                        )
+                        .pathParameters(parameterWithName("challengeId").description("챌린지의 ID"))
+                        .responseFields(
+                                fieldWithPath("message").description("요청 결과 메세지"),
+                                fieldWithPath("code").description("결과 코드"),
+                                fieldWithPath("data").description("없는 경우 비어 있음. 최대 5개 조회"),
+                                fieldWithPath("data[].nickname").description("참가자의 닉네임"),
+                                fieldWithPath("data[].imageURL").description("참가자의 프로필 이미지 URL"),
+                                fieldWithPath("data[].current").description("현재 기록한 개수"),
+                                fieldWithPath("data[].total").description("전체 기록해야 하는 개수")
                         )
                         .tag("Challenge")
                         .build()

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -248,7 +248,7 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
 
         when(challengeApiService.getTogetherChallengers(anyLong())).thenReturn(response);
 
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challenger", 1L)
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challengers", 1L)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -267,8 +267,8 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data").description("없는 경우 비어 있음. 최대 5개 조회"),
                                 fieldWithPath("data[].nickname").description("참가자의 닉네임"),
                                 fieldWithPath("data[].imageURL").description("참가자의 프로필 이미지 URL"),
-                                fieldWithPath("data[].current").description("현재 기록한 개수"),
-                                fieldWithPath("data[].total").description("전체 기록해야 하는 개수")
+                                fieldWithPath("data[].currentRecord").description("현재 기록한 개수"),
+                                fieldWithPath("data[].goalRecord").description("전체 기록해야 하는 개수")
                         )
                         .tag("Challenge")
                         .build()
@@ -282,7 +282,7 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
 
         when(challengeApiService.getChallengerCount(anyLong())).thenReturn(response);
 
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challenger/count", 1L)
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challengers/count", 1L)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -298,7 +298,7 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                         .responseFields(
                                 fieldWithPath("message").description("요청 결과 메세지"),
                                 fieldWithPath("code").description("결과 코드"),
-                                fieldWithPath("data.challengerNumber").description("참가자의 닉네임")
+                                fieldWithPath("data.challengerCount").description("참가자의 닉네임")
                         )
                         .tag("Challenge")
                         .build()

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -274,4 +274,34 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                         .build()
         )));
     }
+
+    @Test
+    @DisplayName("챌린지 참가중인 인원 조회 API")
+    void get_challenger_count() throws Exception {
+        ChallengerCountResponse response = ChallengerCountResponse.of(1000L);
+
+        when(challengeApiService.getChallengerCount(anyLong())).thenReturn(response);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/challenger/count", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        resultActions.andDo(restDocs.document(resource(
+                ResourceSnippetParameters.builder()
+                        .description("챌린지 참가중인 인원 조회 API 입니다.")
+                        .summary("챌린지 참가중인 인원 조회 API")
+                        .requestHeaders(
+                                headerWithName("Authorization").description("유저의 JWT")
+                        )
+                        .pathParameters(parameterWithName("challengeId").description("챌린지의 ID"))
+                        .responseFields(
+                                fieldWithPath("message").description("요청 결과 메세지"),
+                                fieldWithPath("code").description("결과 코드"),
+                                fieldWithPath("data.challengerNumber").description("참가자의 닉네임")
+                        )
+                        .tag("Challenge")
+                        .build()
+        )));
+    }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
@@ -53,6 +53,15 @@ public class InsightQueryRepository {
                 .fetchFirst();
     }
 
+    public Map<Long, Long> countValidPerParticipation(List<ChallengeParticipation> participations) {
+        return queryFactory.select(insight.id.count())
+                .from(insight)
+                .where(insight.challengeParticipation.in(participations))
+                .where(insight.valid.isTrue())
+                .transform(GroupBy.groupBy(challengeParticipation.id).as(insight.count()));
+    }
+
+
     public List<Insight> findForHome(User user, CursorPageable<Long> cPage, Boolean follow) {
         BooleanExpression followFilter = Expressions.asBoolean(true).isTrue();
         if (follow != null && follow)

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/ChallengeDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/ChallengeDomainService.java
@@ -15,6 +15,7 @@ import ccc.keewedomain.service.user.UserDomainService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -86,6 +87,11 @@ public class ChallengeDomainService {
 
     public List<ChallengeParticipation> getFinishedParticipation(User user, Long size) {
         return challengeParticipationQueryRepository.findFinishedParticipation(user, size);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChallengeParticipation> findTogetherChallengeParticipations(Challenge challenge, User user) {
+        return challengeParticipationQueryRepository.findFollowingChallengerParticipations(challenge, user);
     }
 
     private void exitCurrentChallengeIfExist(User challenger) {

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/InsightDomainService.java
@@ -198,6 +198,10 @@ public class InsightDomainService {
         return insightQueryRepository.countByChallenge(challenge);
     }
 
+    public Map<Long, Long> getInsightCountPerParticipation(List<ChallengeParticipation> participations) {
+        return insightQueryRepository.countValidPerParticipation(participations);
+    }
+
     /*****************************************************************
      ********************** private 메소드 영역 분리 *********************
      *****************************************************************/


### PR DESCRIPTION
## 관련 Issue <!-- 관련 이슈를 함께 #200 과 같이 적어주세요. PR과 함께 close 하려면 close 키워드를 붙여주세요. -->
- close #208 
## 작업 내용 <!-- PR 내용을 간단하게 적어주세요. -->
- 챌린지 상세 함께 기록 참가자 목록 조회 API (최대 5개 조회)
  - API 문서화용 테스트 작성
- 챌린지 참가 중인 인원 조회 API
  - API 문서화용 테스트 작성
- 마이 페이지 프로필 조회 API 자기 소개 "introduction" 실제 값 들어가도록 수정
## Figma 링크 <!-- 작업한 내용과 관련된 피그마 링크를 추가해주세요 -->
<!-- 
- [간략한 제목](링크) 
-->
- [챌린지 상세 함께 기록](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3800%3A28287&t=3ekfn9Zd2UPy5I9w-4)
