### PR TITLE
[Fix] 챌린지 상세 조회 API 참가 전, 참가 중 분리

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -132,8 +132,10 @@ public class ChallengeAssembler {
         return ChallengeDetailResponse.of(
                 challenge.getId(),
                 challenge.getName(),
+                challenge.getInterest().getName(),
                 challenge.getIntroduction(),
-                insightCount
+                insightCount,
+                challenge.getCreatedAt().toLocalDate().toString()
         );
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -132,7 +132,6 @@ public class ChallengeAssembler {
     public ChallengeDetailResponse toChallengeDetailResponse(Challenge challenge, Long insightCount) {
         return ChallengeDetailResponse.of(
                 challenge.getName(),
-                challenge.getInterest().getName(),
                 challenge.getIntroduction(),
                 insightCount,
                 challenge.getCreatedAt().toLocalDate().toString()

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -130,7 +131,6 @@ public class ChallengeAssembler {
 
     public ChallengeDetailResponse toChallengeDetailResponse(Challenge challenge, Long insightCount) {
         return ChallengeDetailResponse.of(
-                challenge.getId(),
                 challenge.getName(),
                 challenge.getInterest().getName(),
                 challenge.getIntroduction(),
@@ -159,5 +159,14 @@ public class ChallengeAssembler {
 
     public ChallengerCountResponse toChallengerCountResponse(Long countParticipatingUser) {
         return ChallengerCountResponse.of(countParticipatingUser);
+    }
+
+    public ParticipatingChallengeDetailResponse toParticipatingChallengeDetailResponse(Challenge challenge) {
+        return ParticipatingChallengeDetailResponse.of(
+                challenge.getName(),
+                challenge.getInterest().getName(),
+                challenge.getIntroduction(),
+                challenge.getCreatedAt().toLocalDate().toString()
+        );
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeController.java
@@ -55,13 +55,13 @@ public class ChallengeController {
         return ApiResponse.ok(challengeApiService.getSpecifiedNumberOfChallenge(size));
     }
 
-    @GetMapping("/detail/{challengeId}")
+    @GetMapping("/{challengeId}/detail")
     @FLogging
     public ApiResponse<ChallengeDetailResponse> getChallengeDetail(@PathVariable Long challengeId) {
         return ApiResponse.ok(challengeApiService.getChallengeDetail(challengeId));
     }
 
-    @GetMapping("/detail/participating")
+    @GetMapping("/my/detail")
     @FLogging
     public ApiResponse<ParticipatingChallengeDetailResponse> getMyChallengeDetail() {
         return ApiResponse.ok(challengeApiService.getMyChallengeDetail());

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeController.java
@@ -60,4 +60,10 @@ public class ChallengeController {
     public ApiResponse<ChallengeDetailResponse> getChallengeDetail(@PathVariable Long challengeId) {
         return ApiResponse.ok(challengeApiService.getChallengeDetail(challengeId));
     }
+
+    @GetMapping("/detail/participating")
+    @FLogging
+    public ApiResponse<ParticipatingChallengeDetailResponse> getMyChallengeDetail() {
+        return ApiResponse.ok(challengeApiService.getMyChallengeDetail());
+    }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengeDetailResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengeDetailResponse.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public class ChallengeDetailResponse {
     private Long challengeId;
     private String challengeName;
+    private String challengeCategory;
     private String challengeIntroduction;
     private Long insightCount;
+    private String createdAt;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengeDetailResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ChallengeDetailResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor(staticName = "of")
 public class ChallengeDetailResponse {
     private String challengeName;
-    private String challengeCategory;
     private String challengeIntroduction;
     private Long insightCount;
     private String createdAt;

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeDetailResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeDetailResponse.java
@@ -5,10 +5,9 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(staticName = "of")
-public class ChallengeDetailResponse {
+public class ParticipatingChallengeDetailResponse {
     private String challengeName;
     private String challengeCategory;
     private String challengeIntroduction;
-    private Long insightCount;
     private String createdAt;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -140,7 +140,6 @@ public class ChallengeApiService {
         return challengeAssembler.toChallengerCountResponse(challengeParticipateQueryDomainService.countParticipatingUser(challenge));
     }
 
-    @Transactional(readOnly = true)
     public ParticipatingChallengeDetailResponse getMyChallengeDetail() {
         Challenge challenge = challengeParticipateQueryDomainService.findCurrentParticipationWithChallenge(SecurityUtil.getUserId())
                 .map(ChallengeParticipation::getChallenge)

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -1,20 +1,10 @@
 package ccc.keeweapi.service.challenge;
 
 import ccc.keeweapi.component.ChallengeAssembler;
-import ccc.keeweapi.dto.challenge.ChallengeCreateRequest;
-import ccc.keeweapi.dto.challenge.ChallengeCreateResponse;
-import ccc.keeweapi.dto.challenge.ChallengeDetailResponse;
-import ccc.keeweapi.dto.challenge.ChallengeHistoryListResponse;
-import ccc.keeweapi.dto.challenge.ChallengeInfoResponse;
-import ccc.keeweapi.dto.challenge.ChallengeParticipateRequest;
-import ccc.keeweapi.dto.challenge.ChallengeParticipationResponse;
-import ccc.keeweapi.dto.challenge.ChallengerCountResponse;
-import ccc.keeweapi.dto.challenge.InsightProgressResponse;
-import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
-import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
-import ccc.keeweapi.dto.challenge.TogetherChallengerResponse;
-import ccc.keeweapi.dto.challenge.WeekProgressResponse;
+import ccc.keeweapi.dto.challenge.*;
 import ccc.keeweapi.utils.SecurityUtil;
+import ccc.keewecore.consts.KeeweRtnConsts;
+import ccc.keewecore.exception.KeeweException;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.user.User;
@@ -148,5 +138,13 @@ public class ChallengeApiService {
     public ChallengerCountResponse getChallengerCount(Long challengeId) {
         Challenge challenge = challengeQueryDomainService.getByIdOrElseThrow(challengeId);
         return challengeAssembler.toChallengerCountResponse(challengeParticipateQueryDomainService.countParticipatingUser(challenge));
+    }
+
+    @Transactional(readOnly = true)
+    public ParticipatingChallengeDetailResponse getMyChallengeDetail() {
+        Challenge challenge = challengeParticipateQueryDomainService.findCurrentParticipationWithChallenge(SecurityUtil.getUserId())
+                .map(ChallengeParticipation::getChallenge)
+                .orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR432));
+        return challengeAssembler.toParticipatingChallengeDetailResponse(challenge);
     }
 }

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
@@ -154,7 +154,7 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
     @DisplayName("챌린지 상세 조회 API")
     void get_challenge_detail() throws Exception {
         long challengeId = 1L;
-        ChallengeDetailResponse response = ChallengeDetailResponse.of(challengeId, "챌린지 이름", "챌린지 설명~~", 1000L);
+        ChallengeDetailResponse response = ChallengeDetailResponse.of(challengeId, "챌린지 이름", "개발", "챌린지 설명~~", 1000L, "2019-01-01");
 
         when(challengeApiService.getChallengeDetail(anyLong()))
                 .thenReturn(response);
@@ -175,9 +175,11 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("message").description("요청 결과 메세지"),
                                 fieldWithPath("code").description("결과 코드"),
                                 fieldWithPath("data.challengeId").description("챌린지의 ID"),
+                                fieldWithPath("data.challengeCategory").description("챌린지의 카테고리"),
                                 fieldWithPath("data.challengeName").description("챌린지의 이름"),
                                 fieldWithPath("data.challengeIntroduction").description("챌린지 설명"),
-                                fieldWithPath("data.insightCount").description("챌린지에 기록한 인사이트 수")
+                                fieldWithPath("data.insightCount").description("챌린지에 기록한 인사이트 수"),
+                                fieldWithPath("data.createdAt").description("챌린지의 시작일자 yyyy-mm-dd")
                         )
                         .tag("Challenge")
                         .build()

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
@@ -154,7 +154,7 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
     @DisplayName("챌린지 상세 조회 API")
     void get_challenge_detail() throws Exception {
         long challengeId = 1L;
-        ChallengeDetailResponse response = ChallengeDetailResponse.of(challengeId, "챌린지 이름", "개발", "챌린지 설명~~", 1000L, "2019-01-01");
+        ChallengeDetailResponse response = ChallengeDetailResponse.of("챌린지 이름", "챌린지 설명~~", 1000L, "2019-01-01");
 
         when(challengeApiService.getChallengeDetail(anyLong()))
                 .thenReturn(response);
@@ -174,11 +174,42 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
                         .responseFields(
                                 fieldWithPath("message").description("요청 결과 메세지"),
                                 fieldWithPath("code").description("결과 코드"),
-                                fieldWithPath("data.challengeId").description("챌린지의 ID"),
-                                fieldWithPath("data.challengeCategory").description("챌린지의 카테고리"),
                                 fieldWithPath("data.challengeName").description("챌린지의 이름"),
                                 fieldWithPath("data.challengeIntroduction").description("챌린지 설명"),
                                 fieldWithPath("data.insightCount").description("챌린지에 기록한 인사이트 수"),
+                                fieldWithPath("data.createdAt").description("챌린지의 시작일자 yyyy-mm-dd")
+                        )
+                        .tag("Challenge")
+                        .build()
+        )));
+    }
+
+    @Test
+    @DisplayName("참가중인 챌린지 상세 조회 API")
+    void get_participating_challenge_detail() throws Exception {
+        ParticipatingChallengeDetailResponse response = ParticipatingChallengeDetailResponse.of("챌린지 이름", "개발", "챌린지 소개", "2023-03-05");
+
+        when(challengeApiService.getMyChallengeDetail())
+                .thenReturn(response);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/detail/participating")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        resultActions.andDo(restDocs.document(resource(
+                ResourceSnippetParameters.builder()
+                        .description("참가중인 챌린지 상세 조회 API 입니다.")
+                        .summary("참가중인 챌린지 상세 조회 API")
+                        .requestHeaders(
+                                headerWithName("Authorization").description("유저의 JWT")
+                        )
+                        .responseFields(
+                                fieldWithPath("message").description("요청 결과 메세지"),
+                                fieldWithPath("code").description("결과 코드"),
+                                fieldWithPath("data.challengeName").description("챌린지의 이름"),
+                                fieldWithPath("data.challengeCategory").description("챌린지의 카테고리"),
+                                fieldWithPath("data.challengeIntroduction").description("챌린지 설명"),
                                 fieldWithPath("data.createdAt").description("챌린지의 시작일자 yyyy-mm-dd")
                         )
                         .tag("Challenge")

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeControllerTest.java
@@ -159,7 +159,7 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
         when(challengeApiService.getChallengeDetail(anyLong()))
                 .thenReturn(response);
 
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/detail/{challengeId}", challengeId)
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/{challengeId}/detail", challengeId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
@@ -192,7 +192,7 @@ public class ChallengeControllerTest extends ApiDocumentationTest {
         when(challengeApiService.getMyChallengeDetail())
                 .thenReturn(response);
 
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/detail/participating")
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/my/detail")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- close #234
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->


- ~~챌린지 상세 조회 API 필드 `challengeCategory`, `createAt` 추가~~
- ~~변경 내용 문서화 테스트 반영~~
- 챌린지 상세 조회 참가 전, 참가 중으로 분리
  - 참가 전 챌린지 상세 조회 API 필드 수정(불필요한 필드 제거)
  - 참가 중 챌린지 상세 조회 API 추가
- 챌린지 상세 조회 참가 전, 참가 중 문서화용 테스트 추가
## Figma 링크 <!-- 작업한 내용과 관련된 피그마 링크를 추가해주세요 -->

- [참여 전 챌린지 상세](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3800%3A28283&t=JuMWhs31m8kOgSSO-4)
- [참여 중 챌린지 상세](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=7821%3A37069&t=JuMWhs31m8kOgSSO-4)