### PR TITLE
[Feat] 인사이트 생성 시 챌린지 참가 현황 조회 API 수정 반영

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -62,11 +62,17 @@ public class ChallengeAssembler {
         return ParticipationCheckResponse.of(participation);
     }
 
-    public InsightProgressResponse toParticipationProgressResponse(ChallengeParticipation participation, Long current) {
-        return InsightProgressResponse.of(
+    public MyParticipationProgressResponse toMyParticipationProgressResponse(
+            ChallengeParticipation participation,
+            Long current,
+            boolean todayRecorded,
+            boolean weekCompleted) {
+        return MyParticipationProgressResponse.of(
                 participation.getChallenge().getName(),
                 current,
-                participation.getTotalInsightNumber()
+                participation.getTotalInsightNumber(),
+                todayRecorded,
+                weekCompleted
         );
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -41,7 +41,7 @@ public class ChallengeParticipationController {
     }
 
     @GetMapping("/participation/progress/insight")
-    public ApiResponse<InsightProgressResponse> getMyParticipationProgress() {
+    public ApiResponse<MyParticipationProgressResponse> getMyParticipationProgress() {
         return ApiResponse.ok(challengeApiService.getMyParticipationProgress());
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/MyParticipationProgressResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/MyParticipationProgressResponse.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(staticName = "of")
-public class InsightProgressResponse {
+public class MyParticipationProgressResponse {
     private String name;
     private Long current;
     private Long total;
+    private boolean todayRecorded;
+    private boolean weekCompleted;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -9,7 +9,7 @@ import ccc.keeweapi.dto.challenge.ChallengeInfoResponse;
 import ccc.keeweapi.dto.challenge.ChallengeParticipateRequest;
 import ccc.keeweapi.dto.challenge.ChallengeParticipationResponse;
 import ccc.keeweapi.dto.challenge.ChallengerCountResponse;
-import ccc.keeweapi.dto.challenge.InsightProgressResponse;
+import ccc.keeweapi.dto.challenge.MyParticipationProgressResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeDetailResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
@@ -74,13 +74,15 @@ public class ChallengeApiService {
     }
 
     @Transactional(readOnly = true)
-    public InsightProgressResponse getMyParticipationProgress() {
-        Long userId = SecurityUtil.getUserId();
+    public MyParticipationProgressResponse getMyParticipationProgress() {
+        User user = SecurityUtil.getUser();
 
-        return challengeParticipateQueryDomainService.findCurrentParticipationWithChallenge(userId)
+        return challengeParticipateQueryDomainService.findCurrentParticipationWithChallenge(user.getId())
                 .map(participation -> {
                     Long current = insightQueryDomainService.getRecordedInsightNumber(participation);
-                    return challengeAssembler.toParticipationProgressResponse(participation, current);
+                    boolean todayRecorded = insightQueryDomainService.isTodayRecorded(user);
+                    boolean weekCompleted =  insightQueryDomainService.isThisWeekCompleted(participation);
+                    return challengeAssembler.toMyParticipationProgressResponse(participation, current, todayRecorded, weekCompleted);
                 })
                 .orElse(null);
     }

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -125,7 +125,7 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
         Long current = 4L;
         Long total = 16L;
         when(challengeApiService.getMyParticipationProgress())
-                .thenReturn(InsightProgressResponse.of(name, current, total));
+                .thenReturn(MyParticipationProgressResponse.of(name, current, total));
 
         ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/participation/progress/insight")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -125,7 +125,7 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
         Long current = 4L;
         Long total = 16L;
         when(challengeApiService.getMyParticipationProgress())
-                .thenReturn(MyParticipationProgressResponse.of(name, current, total));
+                .thenReturn(MyParticipationProgressResponse.of(name, current, total, false, true));
 
         ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/participation/progress/insight")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
@@ -145,7 +145,9 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data").description("참가중이지 않은 경우 null"),
                                 fieldWithPath("data.name").description("참가중인 챌린지의 이름"),
                                 fieldWithPath("data.current").description("지금까지 기록한 인사이트의 수"),
-                                fieldWithPath("data.total").description("총 기록해야 하는 인사이트의 수")
+                                fieldWithPath("data.total").description("총 기록해야 하는 인사이트의 수"),
+                                fieldWithPath("data.todayRecorded").description("오늘 기록 여부"),
+                                fieldWithPath("data.weekCompleted").description("주간 목표 달성 여부")
                         )
                         .tag("ChallengeParticipation")
                         .build()

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/ChallengeParticipation.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/ChallengeParticipation.java
@@ -77,7 +77,7 @@ public class ChallengeParticipation extends BaseTimeEntity {
     public long getCurrentWeek() {
         LocalDate createdAt = getCreatedAt().toLocalDate();
         LocalDate today = LocalDate.now();
-        Period between = Period.between(today, createdAt);
+        Period between = Period.between(createdAt, today);
 
         return between.getDays() / 7 + 1; // 1주차부터 시작
     }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
@@ -12,6 +12,9 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -176,5 +179,16 @@ public class InsightQueryRepository {
 
     private BooleanExpression drawerIdEq(Long drawerId) {
         return drawerId != null ? insight.drawer.id.eq(drawerId) : null;
+    }
+
+    public Long countValidByCreatedAtAfterAndParticipation(ChallengeParticipation participation, LocalDateTime start) {
+        return queryFactory
+                .select(insight.count())
+                .from(insight)
+                .where(insight.challengeParticipation.eq(participation)
+                        .and(insight.valid.isTrue())
+                        .and(insight.createdAt.goe(start))
+                )
+                .fetchFirst();
     }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
@@ -180,15 +180,4 @@ public class InsightQueryRepository {
     private BooleanExpression drawerIdEq(Long drawerId) {
         return drawerId != null ? insight.drawer.id.eq(drawerId) : null;
     }
-
-    public Long countValidByCreatedAtAfterAndParticipation(ChallengeParticipation participation, LocalDateTime start) {
-        return queryFactory
-                .select(insight.count())
-                .from(insight)
-                .where(insight.challengeParticipation.eq(participation)
-                        .and(insight.valid.isTrue())
-                        .and(insight.createdAt.goe(start))
-                )
-                .fetchFirst();
-    }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
@@ -159,15 +159,15 @@ public class InsightQueryDomainService {
         return insightQueryRepository.existByWriterAndCreatedAtBetweenAndValidTrue(user, startDate, endDate);
     }
 
-    private ReactionAggregationGetDto getCurrentReactionAggregation(Long insightId) {
-        return ReactionAggregationGetDto.createByCnt(cReactionCountRepository.findByIdWithMissHandle(insightId, () ->
-                reactionAggregationRepository.findDtoByInsightId(insightId)
-        ));
-    }
-
     public boolean isThisWeekCompleted(ChallengeParticipation participation) {
         Long validNumber = insightQueryRepository.countValidByParticipation(participation);
         log.info("validNumber = {}, currentWeek = {}, insightPerWeek = {}", validNumber, participation.getCurrentWeek(), participation.getInsightPerWeek());
         return validNumber.equals(participation.getCurrentWeek() * participation.getInsightPerWeek());
+    }
+
+    private ReactionAggregationGetDto getCurrentReactionAggregation(Long insightId) {
+        return ReactionAggregationGetDto.createByCnt(cReactionCountRepository.findByIdWithMissHandle(insightId, () ->
+                reactionAggregationRepository.findDtoByInsightId(insightId)
+        ));
     }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
@@ -161,7 +161,7 @@ public class InsightQueryDomainService {
 
     public boolean isThisWeekCompleted(ChallengeParticipation participation) {
         Long validNumber = insightQueryRepository.countValidByParticipation(participation);
-        log.info("validNumber = {}, currentWeek = {}, insightPerWeek = {}", validNumber, participation.getCurrentWeek(), participation.getInsightPerWeek());
+        log.info("[IQDS::isThisWeekCompleted] validNumber = {}, currentWeek = {}, insightPerWeek = {}", validNumber, participation.getCurrentWeek(), participation.getInsightPerWeek());
         return validNumber.equals(participation.getCurrentWeek() * participation.getInsightPerWeek());
     }
 

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/InsightQueryDomainService.java
@@ -164,5 +164,10 @@ public class InsightQueryDomainService {
                 reactionAggregationRepository.findDtoByInsightId(insightId)
         ));
     }
-}
 
+    public boolean isThisWeekCompleted(ChallengeParticipation participation) {
+        Long validNumber = insightQueryRepository.countValidByParticipation(participation);
+        log.info("validNumber = {}, currentWeek = {}, insightPerWeek = {}", validNumber, participation.getCurrentWeek(), participation.getInsightPerWeek());
+        return validNumber.equals(participation.getCurrentWeek() * participation.getInsightPerWeek());
+    }
+}


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- close #254 
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->


- 챌린지 참가 현황 조회 API todayRecorded, weekCompleted 필드 추가
## Figma 링크 <!-- 작업한 내용과 관련된 피그마 링크를 추가해주세요 -->

- [현황별 메시지](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3679-25197&t=DyGYVHLXebJQVbUU-4)
<img width="964" alt="image" src="https://user-images.githubusercontent.com/29909282/226109407-de12a418-de04-406d-976d-4efc6a4851ed.png">