### PR TITLE
[Feat] 챌린지 참가 정보 수정 API, 참가중인 챌린지 조회 API 수정

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -118,12 +118,11 @@ public class ChallengeAssembler {
         );
     }
 
-    public ParticipatingChallengeResponse toMyChallengeResponse(ChallengeParticipation participation, Long participatingUser) {
+    public ParticipatingChallengeResponse toMyChallengeResponse(ChallengeParticipation participation) {
         Challenge challenge = participation.getChallenge();
         return ParticipatingChallengeResponse.of(
                 challenge.getId(),
                 challenge.getName(),
-                participatingUser,
                 challenge.getInterest().getName(),
                 participation.getCreatedAt().toLocalDate().toString()
         );

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -124,6 +124,10 @@ public class ChallengeAssembler {
                 challenge.getId(),
                 challenge.getName(),
                 challenge.getInterest().getName(),
+                participation.getMyTopic(),
+                participation.getInsightPerWeek(),
+                participation.getDuration(),
+                participation.getEndDate().toString(),
                 participation.getCreatedAt().toLocalDate().toString()
         );
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -206,7 +206,7 @@ public class ChallengeAssembler {
         return ChallengeStatisticsResponse.of(viewCount, reactionCount, commentCount, bookmarkCount, shareCount);
     }
 
-    public ParticipationUpdateDto toParticipationUpdateDto(ParticipationUpdateRequest request) {
-        return ParticipationUpdateDto.of(request.getMyTopic(), request.getInsightPerWeek(), request.getDuration());
+    public ParticipationUpdateDto toParticipationUpdateDto(Long userId, ParticipationUpdateRequest request) {
+        return ParticipationUpdateDto.of(userId, request.getMyTopic(), request.getInsightPerWeek(), request.getDuration());
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ChallengeAssembler.java
@@ -17,10 +17,12 @@ import ccc.keeweapi.dto.challenge.OpenedChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeDetailResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
+import ccc.keeweapi.dto.challenge.ParticipationUpdateRequest;
 import ccc.keeweapi.dto.challenge.WeekProgressResponse;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.dto.challenge.ChallengeCreateDto;
 import ccc.keewedomain.dto.challenge.ChallengeParticipateDto;
+import ccc.keewedomain.dto.challenge.ParticipationUpdateDto;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.user.User;
@@ -202,5 +204,9 @@ public class ChallengeAssembler {
             Long shareCount
     ) {
         return ChallengeStatisticsResponse.of(viewCount, reactionCount, commentCount, bookmarkCount, shareCount);
+    }
+
+    public ParticipationUpdateDto toParticipationUpdateDto(ParticipationUpdateRequest request) {
+        return ParticipationUpdateDto.of(request.getMyTopic(), request.getInsightPerWeek(), request.getDuration());
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -44,7 +44,7 @@ public class ChallengeParticipationController {
 
     @GetMapping("/participating")
     public ApiResponse<ParticipatingChallengeResponse> getParticipatingChallenge() {
-        return ApiResponse.ok(challengeApiService.getParticipatingChallenege());
+        return ApiResponse.ok(challengeApiService.getParticipatingChallenge());
     }
 
     @GetMapping(value = "/participation/check")

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationController.java
@@ -10,6 +10,7 @@ import ccc.keeweapi.dto.challenge.FriendResponse;
 import ccc.keeweapi.dto.challenge.MyParticipationProgressResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
+import ccc.keeweapi.dto.challenge.ParticipationUpdateRequest;
 import ccc.keeweapi.dto.challenge.WeekProgressResponse;
 import ccc.keeweapi.service.challenge.ChallengeApiService;
 import ccc.keeweapi.service.challenge.query.ChallengeParticipationQueryApiService;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,6 +47,12 @@ public class ChallengeParticipationController {
     @GetMapping("/participating")
     public ApiResponse<ParticipatingChallengeResponse> getParticipatingChallenge() {
         return ApiResponse.ok(challengeApiService.getParticipatingChallenge());
+    }
+
+    @PatchMapping("/participating")
+    public ApiResponse<Void> updateParticipation(@RequestBody ParticipationUpdateRequest request) {
+        challengeApiService.updateParticipation(request);
+        return ApiResponse.ok();
     }
 
     @GetMapping(value = "/participation/check")

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeResponse.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 public class ParticipatingChallengeResponse {
     private Long challengeId;
     private String name;
-    private Long participatingUserNumber;
     private String interest;
     private String startDate;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipatingChallengeResponse.java
@@ -9,5 +9,9 @@ public class ParticipatingChallengeResponse {
     private Long challengeId;
     private String name;
     private String interest;
+    private String myTopic;
+    private int insightPerWeek;
+    private int duration;
+    private String endDate;
     private String startDate;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipationUpdateRequest.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/challenge/ParticipationUpdateRequest.java
@@ -1,0 +1,19 @@
+package ccc.keeweapi.dto.challenge;
+
+import ccc.keeweapi.validator.annotations.GraphemeLength;
+import lombok.Getter;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@Getter
+public class ParticipationUpdateRequest {
+    @GraphemeLength(max = 150)
+    private String myTopic;
+
+    @Min(1) @Max(7)
+    private int insightPerWeek;
+
+    @Min(2) @Max(8)
+    private int duration;
+}

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -13,10 +13,12 @@ import ccc.keeweapi.dto.challenge.MyParticipationProgressResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeDetailResponse;
 import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
+import ccc.keeweapi.dto.challenge.ParticipationUpdateRequest;
 import ccc.keeweapi.dto.challenge.WeekProgressResponse;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.exception.KeeweException;
+import ccc.keewedomain.dto.challenge.ParticipationUpdateDto;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.user.User;
@@ -160,5 +162,12 @@ public class ChallengeApiService {
                 .map(participation -> insightQueryDomainService.getInsightCountByChallenge(participation.getChallenge(), writerId))
                 .orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR432));
         return challengeAssembler.toChallengeInsightNumberResponse(insightNumber);
+    }
+
+    @Transactional
+    public void updateParticipation(ParticipationUpdateRequest request) {
+        ChallengeParticipation participation = challengeParticipateQueryDomainService.getCurrentChallengeParticipation(SecurityUtil.getUser());
+        ParticipationUpdateDto dto = challengeAssembler.toParticipationUpdateDto(request);
+        challengeCommandDomainService.updateParticipation(participation, dto);
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -99,12 +99,9 @@ public class ChallengeApiService {
     }
 
     @Transactional(readOnly = true)
-    public ParticipatingChallengeResponse getParticipatingChallenege() {
+    public ParticipatingChallengeResponse getParticipatingChallenge() {
         return challengeParticipateQueryDomainService.findCurrentChallengeParticipation(SecurityUtil.getUser())
-                .map(participation -> {
-                    Long participatingUser = challengeParticipateQueryDomainService.countParticipatingUser(participation.getChallenge());
-                    return challengeAssembler.toMyChallengeResponse(participation, participatingUser);
-                })
+                .map(challengeAssembler::toMyChallengeResponse)
                 .orElse(null);
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -166,8 +166,7 @@ public class ChallengeApiService {
 
     @Transactional
     public void updateParticipation(ParticipationUpdateRequest request) {
-        ChallengeParticipation participation = challengeParticipateQueryDomainService.getCurrentChallengeParticipation(SecurityUtil.getUser());
-        ParticipationUpdateDto dto = challengeAssembler.toParticipationUpdateDto(request);
-        challengeCommandDomainService.updateParticipation(participation, dto);
+        ParticipationUpdateDto dto = challengeAssembler.toParticipationUpdateDto(SecurityUtil.getUserId(), request);
+        challengeCommandDomainService.updateParticipation(dto);
     }
 }

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -390,6 +391,37 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("code").description("결과 코드"),
                                 fieldWithPath("data").description("데이터, 오류 시 null"),
                                 fieldWithPath("data.count").description("종료된 챌린지 개수")
+                        )
+                        .tag("ChallengeParticipation")
+                        .build()
+        )));
+    }
+
+    @Test
+    @DisplayName("챌린지 참가 정보 수정")
+    void update_participation() throws Exception {
+        JSONObject request = new JSONObject()
+                .put("myTopic", "나만의 토픽")
+                .put("insightPerWeek", 2)
+                .put("duration", 4);
+
+        ResultActions resultActions = mockMvc.perform(patch("/api/v1/challenge/participating")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
+                        .content(request.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        resultActions.andDo(restDocs.document(resource(
+                ResourceSnippetParameters.builder()
+                        .description("챌린지 참가 정보 수정 API 입니다.")
+                        .summary("챌린지 참가 정보 수정 API")
+                        .requestHeaders(
+                                headerWithName("Authorization").description("유저의 JWT")
+                        )
+                        .responseFields(
+                                fieldWithPath("message").description("요청 결과 메세지"),
+                                fieldWithPath("code").description("결과 코드"),
+                                fieldWithPath("data").description("성공한 경우 null")
                         )
                         .tag("ChallengeParticipation")
                         .build()

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -206,12 +206,11 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
     void home_my_challenge() throws Exception {
         long challengeId = 1L;
         String name = "챌린지 이름";
-        Long participatingUser = 9999L;
         String interest = "프론트";
         String startDate = "2023-02-04";
-        ParticipatingChallengeResponse response = ParticipatingChallengeResponse.of(challengeId, name, participatingUser, interest, startDate);
+        ParticipatingChallengeResponse response = ParticipatingChallengeResponse.of(challengeId, name, interest, startDate);
 
-        when(challengeApiService.getParticipatingChallenege()).thenReturn(response);
+        when(challengeApiService.getParticipatingChallenge()).thenReturn(response);
 
         ResultActions resultActions = mockMvc.perform(get("/api/v1/challenge/participating")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + JWT)
@@ -231,7 +230,6 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data").description("참가중이지 않은 경우 null"),
                                 fieldWithPath("data.challengeId").description("참가중인 챌린지의 ID"),
                                 fieldWithPath("data.name").description("참가중인 챌린지의 이름"),
-                                fieldWithPath("data.participatingUserNumber").description("도전(참가)중인 유저의 수"),
                                 fieldWithPath("data.interest").description("관심사"),
                                 fieldWithPath("data.startDate").description("챌린지에 참가한 날짜")
                         )

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/challenge/ChallengeParticipationControllerTest.java
@@ -207,8 +207,12 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
         long challengeId = 1L;
         String name = "챌린지 이름";
         String interest = "프론트";
+        String myTopic = "나만의 주제";
+        int insightPerWeek = 2;
+        int duration = 2;
+        String endDate = "2023-02-17";
         String startDate = "2023-02-04";
-        ParticipatingChallengeResponse response = ParticipatingChallengeResponse.of(challengeId, name, interest, startDate);
+        ParticipatingChallengeResponse response = ParticipatingChallengeResponse.of(challengeId, name, interest, myTopic, insightPerWeek, duration, endDate, startDate);
 
         when(challengeApiService.getParticipatingChallenge()).thenReturn(response);
 
@@ -231,7 +235,11 @@ public class ChallengeParticipationControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data.challengeId").description("참가중인 챌린지의 ID"),
                                 fieldWithPath("data.name").description("참가중인 챌린지의 이름"),
                                 fieldWithPath("data.interest").description("관심사"),
-                                fieldWithPath("data.startDate").description("챌린지에 참가한 날짜")
+                                fieldWithPath("data.myTopic").description("나만의 주제"),
+                                fieldWithPath("data.insightPerWeek").description("주마다 올릴 인사이트 개수"),
+                                fieldWithPath("data.duration").description("참가 기간 단위: 주"),
+                                fieldWithPath("data.startDate").description("챌린지에 참가한 날짜"),
+                                fieldWithPath("data.endDate").description("챌린지 종료 예정일")
                         )
                         .tag("ChallengeParticipation")
                         .build()

--- a/keewe-core/src/main/java/ccc/keewecore/consts/KeeweRtnConsts.java
+++ b/keewe-core/src/main/java/ccc/keewecore/consts/KeeweRtnConsts.java
@@ -29,7 +29,9 @@ public enum KeeweRtnConsts {
 
     ERR430(KeeweRtnGrp.Validation, 430, "챌린지를 찾을 수 없어요."),
     ERR431(KeeweRtnGrp.Validation, 431, "이미 챌린지에 참여중이에요."),
-    ERR432(KeeweRtnGrp.Validation, 432, "참가중인 챌린지가 없어요"),
+    ERR432(KeeweRtnGrp.Validation, 432, "참가중인 챌린지가 없어요."),
+    ERR433(KeeweRtnGrp.Validation, 433, "종료일을 오늘 이전으로 설정할 수 없어요."),
+    ERR434(KeeweRtnGrp.Validation, 434, "달성 불가능한 기록 횟수로 변경할 수 없어요."),
 
     ERR440(KeeweRtnGrp.Validation, 440, "서랍을 찾을 수 없어요"),
     ERR441(KeeweRtnGrp.Validation, 441, "이미 등록된 서랍 이름이에요"),

--- a/keewe-domain/src/main/java/ccc/keewedomain/dto/challenge/ParticipationUpdateDto.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/dto/challenge/ParticipationUpdateDto.java
@@ -1,0 +1,12 @@
+package ccc.keewedomain.dto.challenge;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ParticipationUpdateDto {
+    private String myTopic;
+    private int insightPerWeek;
+    private int duration;
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/dto/challenge/ParticipationUpdateDto.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/dto/challenge/ParticipationUpdateDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(staticName = "of")
 public class ParticipationUpdateDto {
+    private Long userId;
     private String myTopic;
     private int insightPerWeek;
     private int duration;

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/ChallengeParticipation.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/ChallengeParticipation.java
@@ -1,5 +1,7 @@
 package ccc.keewedomain.persistence.domain.challenge;
 
+import ccc.keewecore.consts.KeeweRtnConsts;
+import ccc.keewecore.exception.KeeweException;
 import ccc.keewedomain.persistence.domain.challenge.enums.ChallengeParticipationStatus;
 import ccc.keewedomain.persistence.domain.common.BaseTimeEntity;
 import ccc.keewedomain.persistence.domain.user.User;
@@ -64,16 +66,6 @@ public class ChallengeParticipation extends BaseTimeEntity {
         return participation;
     }
 
-    public void cancel() {
-        this.endDate = LocalDate.now();
-        this.status = ChallengeParticipationStatus.CANCELED;
-    }
-
-    private void initEndDate() {
-        LocalDate createdDate = getCreatedAt().toLocalDate();
-        this.endDate = createdDate.minusDays(1).plusWeeks(duration);
-    }
-
     // 현재가 몇 주차인지
     public long getCurrentWeek() {
         LocalDate createdAt = getCreatedAt().toLocalDate();
@@ -91,12 +83,37 @@ public class ChallengeParticipation extends BaseTimeEntity {
         return (long) (insightPerWeek * duration);
     }
 
+    public void update(String myTopic, int insightPerWeek, int duration) {
+        this.myTopic = myTopic;
+        this.insightPerWeek = insightPerWeek;
+        this.duration = duration;
+        initEndDate();
+    }
+
     public void expire(LocalDate endDate) {
         this.endDate = endDate;
         this.status = ChallengeParticipationStatus.EXPIRED;
     }
 
+    public void cancel() {
+        this.endDate = LocalDate.now();
+        this.status = ChallengeParticipationStatus.CANCELED;
+    }
+
     public void complete() {
         this.status = ChallengeParticipationStatus.COMPLETED;
+    }
+
+    private void initEndDate() {
+        LocalDate createdDate = getCreatedAt().toLocalDate();
+        LocalDate newEndDate = createdDate.minusDays(1).plusWeeks(duration);
+        validateEndDate(newEndDate);
+        this.endDate = newEndDate;
+    }
+
+    private void validateEndDate(LocalDate newEndDate) {
+        if(newEndDate.isBefore(LocalDate.now())) {
+            throw new KeeweException(KeeweRtnConsts.ERR433);
+        }
     }
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/command/ChallengeCommandDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/command/ChallengeCommandDomainService.java
@@ -47,7 +47,8 @@ public class ChallengeCommandDomainService {
         });
     }
 
-    public void updateParticipation(ChallengeParticipation participation, ParticipationUpdateDto dto) {
+    public void updateParticipation(ParticipationUpdateDto dto) {
+        ChallengeParticipation participation = challengeParticipateQueryDomainService.getCurrentParticipationByUserId(dto.getUserId());
         validateInsightPerWeek(participation, dto.getInsightPerWeek());
         participation.update(dto.getMyTopic(), dto.getInsightPerWeek(), dto.getDuration());
     }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/command/ChallengeCommandDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/command/ChallengeCommandDomainService.java
@@ -1,18 +1,25 @@
 package ccc.keewedomain.service.challenge.command;
 
+import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.consts.LockType;
+import ccc.keewecore.exception.KeeweException;
 import ccc.keewecore.utils.RedisLockUtils;
 import ccc.keewedomain.dto.challenge.ChallengeCreateDto;
 import ccc.keewedomain.dto.challenge.ChallengeParticipateDto;
+import ccc.keewedomain.dto.challenge.ParticipationUpdateDto;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.challenge.ChallengeRepository;
 import ccc.keewedomain.service.challenge.query.ChallengeParticipateQueryDomainService;
 import ccc.keewedomain.service.challenge.query.ChallengeQueryDomainService;
+import ccc.keewedomain.service.insight.query.InsightQueryDomainService;
 import ccc.keewedomain.service.user.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.Period;
 
 @RequiredArgsConstructor
 @Service
@@ -22,6 +29,7 @@ public class ChallengeCommandDomainService {
     private final ChallengeQueryDomainService challengeQueryDomainService;
     private final ChallengeParticipateQueryDomainService challengeParticipateQueryDomainService;
     private final UserDomainService userDomainService;
+    private final InsightQueryDomainService insightQueryDomainService;
     private final RedisLockUtils redisLockUtils;
 
     public Challenge save(ChallengeCreateDto dto) {
@@ -37,6 +45,25 @@ public class ChallengeCommandDomainService {
             Challenge challenge = challengeQueryDomainService.getByIdOrElseThrow(dto.getChallengeId());
             return challenge.participate(challenger, dto.getMyTopic(), dto.getInsightPerWeek(), dto.getDuration());
         });
+    }
+
+    public void updateParticipation(ChallengeParticipation participation, ParticipationUpdateDto dto) {
+        validateInsightPerWeek(participation, dto.getInsightPerWeek());
+        participation.update(dto.getMyTopic(), dto.getInsightPerWeek(), dto.getDuration());
+    }
+
+    // 남은 일자 < insightPerWeek 확인
+    private void validateInsightPerWeek(ChallengeParticipation participation, int insightPerWeek) {
+        LocalDateTime start = participation.getStartDateOfThisWeek().atStartOfDay();
+        LocalDateTime end = LocalDateTime.now();
+        Long thisWeekRecordCount = insightQueryDomainService.countInsightCreatedAtBetween(participation, start, end);
+        int remainDays = 7 - Period.between(start.toLocalDate(), end.toLocalDate()).getDays();
+        if(insightQueryDomainService.isTodayRecorded(participation.getChallenger())) {
+            remainDays -= 1;
+        }
+        if(insightPerWeek - thisWeekRecordCount > remainDays) {
+            throw new KeeweException(KeeweRtnConsts.ERR434);
+        }
     }
 
     private void exitCurrentChallengeIfExist(User challenger) {

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/query/ChallengeParticipateQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/challenge/query/ChallengeParticipateQueryDomainService.java
@@ -38,6 +38,10 @@ public class ChallengeParticipateQueryDomainService {
         return findCurrentChallengeParticipation(user).orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR432));
     }
 
+    public ChallengeParticipation getCurrentParticipationByUserId(Long userId) {
+        return findCurrentParticipationByUserId(userId).orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR432));
+    }
+
     public Optional<ChallengeParticipation> findCurrentParticipationByUserId(Long userId) {
         return challengeParticipationQueryRepository.findByUserIdAndStatus(userId, CHALLENGING);
     }


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- close #269
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->


- 참가중인 챌린지 조회 API 수정
  - 참가 정보 추가
  - 참가자 수 필드 제거(참가자 수 조회 API와 기능 중복)
- 챌린지 참가 정보 수정 API 추가
  - 이번 주 남은 day보다 더 많은 인사이트를 작성해야 하는 경우 예외
  - 오늘보다 이전으로 duration을 설정하는 경우 fail
## Figma 링크 <!-- 작업한 내용과 관련된 피그마 링크를 추가해주세요 -->

- [내 목표 수정](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3806-29663&t=Tw9meND78y9MRR5N-4)