### PR TITLE
[Fix] 미리보기에서 차단된 유저의 댓글을 제외

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/challenge/ChallengeApiService.java
@@ -15,7 +15,7 @@ import ccc.keeweapi.dto.challenge.ParticipatingChallengeResponse;
 import ccc.keeweapi.dto.challenge.ParticipationCheckResponse;
 import ccc.keeweapi.dto.challenge.ParticipationUpdateRequest;
 import ccc.keeweapi.dto.challenge.WeekProgressResponse;
-import ccc.keeweapi.utils.BlockUtil;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.exception.KeeweException;
@@ -53,7 +53,7 @@ public class ChallengeApiService {
     private final InsightQueryDomainService insightQueryDomainService;
     private final ProfileQueryDomainService profileQueryDomainService;
     private final ChallengeAssembler challengeAssembler;
-    private final BlockUtil blockUtil;
+    private final BlockedResourceManager blockedResourceManager;
 
     @Transactional
     public ChallengeCreateResponse createChallenge(ChallengeCreateRequest request) {
@@ -145,7 +145,7 @@ public class ChallengeApiService {
                         followingIdSet.contains(participation.getChallenger().getId()))
                 )
                 .collect(Collectors.toList());
-        return blockUtil.filterUserInResponses(responses);
+        return blockedResourceManager.filterBlockedUsers(responses);
     }
 
     @Transactional(readOnly = true)

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightCommandApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightCommandApiService.java
@@ -1,7 +1,7 @@
 package ccc.keeweapi.service.insight.command;
 
 import ccc.keeweapi.component.InsightAssembler;
-import ccc.keeweapi.utils.BlockUtil;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.dto.insight.request.InsightCreateRequest;
 import ccc.keeweapi.dto.insight.request.InsightUpdateRequest;
 import ccc.keeweapi.dto.insight.response.BookmarkToggleResponse;
@@ -27,7 +27,7 @@ public class InsightCommandApiService {
     private final BookmarkCommandDomainService bookmarkCommandDomainService;
     private final InsightCommandDomainService insightCommandDomainService;
     private final InsightAssembler insightAssembler;
-    private final BlockUtil blockUtil;
+    private final BlockedResourceManager blockedResourceManager;
 
     @TitleEventPublish(titleCategory = TitleCategory.INSIGHT)
     public InsightCreateResponse create(InsightCreateRequest request) {
@@ -43,7 +43,7 @@ public class InsightCommandApiService {
     }
 
     public InsightViewIncrementResponse incrementViewCount(Long insightId) {
-        blockUtil.checkInsightWriter(insightId);
+        blockedResourceManager.validateAccessibleInsight(insightId);
         Long viewCount = insightCommandDomainService.incrementViewCount(insightAssembler.toInsightViewIncrementDto(insightId));
         return insightAssembler.toInsightViewIncrementResponse(viewCount);
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightCommentCommandApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightCommentCommandApiService.java
@@ -7,7 +7,7 @@ import ccc.keeweapi.dto.insight.response.CommentDeleteResponse;
 import ccc.keewedomain.persistence.domain.insight.Comment;
 import ccc.keewedomain.persistence.domain.notification.Notification;
 import ccc.keewedomain.persistence.domain.notification.enums.NotificationContents;
-import ccc.keewedomain.service.insight.CommentDomainService;
+import ccc.keewedomain.service.insight.command.CommentCommandDomainService;
 import ccc.keewedomain.service.notification.command.NotificationCommandDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class InsightCommentCommandApiService {
 
-    private final CommentDomainService commentDomainService;
+    private final CommentCommandDomainService commentCommandDomainService;
     private final InsightAssembler insightAssembler;
     private final NotificationCommandDomainService notificationCommandDomainService;
 
     @Transactional
     public CommentCreateResponse create(CommentCreateRequest request) {
-        Comment comment = commentDomainService.create(insightAssembler.toCommentCreateDto(request));
+        Comment comment = commentCommandDomainService.create(insightAssembler.toCommentCreateDto(request));
         afterLeaveComment(comment);
         return insightAssembler.toCommentCreateResponse(comment);
     }
@@ -33,7 +33,7 @@ public class InsightCommentCommandApiService {
     @Transactional
     public CommentDeleteResponse delete(Long commentId) {
         return insightAssembler.toCommentDeleteResponse(
-                commentDomainService.delete(insightAssembler.toCommentDeleteDto(commentId)));
+                commentCommandDomainService.delete(insightAssembler.toCommentDeleteDto(commentId)));
     }
 
     public void afterLeaveComment(Comment comment) {

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightReactionCommandApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/command/InsightReactionCommandApiService.java
@@ -1,7 +1,7 @@
 package ccc.keeweapi.service.insight.command;
 
 import ccc.keeweapi.component.ReactionAssembler;
-import ccc.keeweapi.utils.BlockUtil;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.dto.insight.request.ReactRequest;
 import ccc.keeweapi.dto.insight.response.ReactResponse;
 import ccc.keewedomain.dto.insight.ReactionDto;
@@ -14,10 +14,10 @@ import org.springframework.stereotype.Service;
 public class InsightReactionCommandApiService {
     private final ReactionAssembler reactionAssembler;
     private final ReactionDomainService reactionDomainService;
-    private final BlockUtil blockUtil;
+    private final BlockedResourceManager blockedResourceManager;
 
     public ReactResponse react(ReactRequest request) {
-        blockUtil.checkInsightWriter(request);
+        blockedResourceManager.validateAccessibleInsight(request);
         ReactionDto reactionDto = reactionDomainService.react(reactionAssembler.toReactionIncrementDto(request));
         return reactionAssembler.toReactResponse(reactionDto);
     }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
@@ -1,16 +1,16 @@
 package ccc.keeweapi.service.insight.query;
 
 import ccc.keeweapi.component.CommentAssembler;
-import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.dto.insight.response.CommentResponse;
 import ccc.keeweapi.dto.insight.response.InsightCommentCountResponse;
 import ccc.keeweapi.dto.insight.response.PreviewCommentResponse;
 import ccc.keeweapi.dto.insight.response.ReplyResponse;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.persistence.domain.insight.Comment;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
-import ccc.keewedomain.service.insight.CommentDomainService;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class InsightCommentQueryApiService {
 
-    private final CommentDomainService commentDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
     private final CommentAssembler commentAssembler;
     private final BlockedResourceManager blockedResourceManager;
 
@@ -31,8 +31,8 @@ public class InsightCommentQueryApiService {
     public List<PreviewCommentResponse> getPreviewComments(Long insightId) {
         blockedResourceManager.validateAccessibleInsight(insightId);
         User user = SecurityUtil.getUser();
-        List<Comment> comments = commentDomainService.getCommentsWithoutBlocked(insightId, CursorPageable.of(Long.MAX_VALUE, 3L), user.getId());
-        commentDomainService.findLatestCommentByWriter(user, insightId)
+        List<Comment> comments = commentQueryDomainService.getCommentsWithoutBlocked(insightId, CursorPageable.of(Long.MAX_VALUE, 3L), user.getId());
+        commentQueryDomainService.findLatestCommentByWriter(user, insightId)
                 .ifPresent(myLatestComment -> {
                     // note. 나의 최신 댓글이 기존의 리스트에서 존재하는 경우 제거. 나의 최신 댓글을 맨 앞에 추가.
                     comments.removeIf(comment -> comment.getId().equals(myLatestComment.getId()));
@@ -49,9 +49,9 @@ public class InsightCommentQueryApiService {
     @Transactional(readOnly = true)
     public List<CommentResponse> getCommentsWithFirstReply(Long insightId, CursorPageable<Long> cPage) {
         blockedResourceManager.validateAccessibleInsight(insightId);
-        List<Comment> comments = commentDomainService.getComments(insightId, cPage);
-        Map<Long, Comment> firstReplyPerParentId = commentDomainService.getFirstReplies(comments);
-        Map<Long, Long> replyNumberPerParentId = commentDomainService.getReplyNumbers(comments);
+        List<Comment> comments = commentQueryDomainService.getComments(insightId, cPage);
+        Map<Long, Comment> firstReplyPerParentId = commentQueryDomainService.getFirstReplies(comments);
+        Map<Long, Long> replyNumberPerParentId = commentQueryDomainService.getReplyNumbers(comments);
 
         List<CommentResponse> responses = comments.stream()
                 .map(comment -> commentAssembler.toCommentResponse(
@@ -65,7 +65,7 @@ public class InsightCommentQueryApiService {
 
     @Transactional(readOnly = true)
     public List<ReplyResponse> getReplies(Long parentId, CursorPageable<Long> cPage) {
-        List<ReplyResponse> responses = commentDomainService.getReplies(parentId, cPage).stream()
+        List<ReplyResponse> responses = commentQueryDomainService.getReplies(parentId, cPage).stream()
                 .map(commentAssembler::toReplyResponse)
                 .collect(Collectors.toList());
         return blockedResourceManager.filterBlockedUsers(responses);
@@ -74,6 +74,6 @@ public class InsightCommentQueryApiService {
     public InsightCommentCountResponse getCommentCount(Long insightId) {
         blockedResourceManager.validateAccessibleInsight(insightId);
         Long userId = SecurityUtil.getUserId();
-        return commentAssembler.toInsightCommentCountResponse(commentDomainService.countByInsightId(insightId, userId));
+        return commentAssembler.toInsightCommentCountResponse(commentQueryDomainService.countByInsightId(insightId, userId));
     }
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
@@ -8,6 +8,7 @@ import ccc.keeweapi.dto.insight.response.PreviewCommentResponse;
 import ccc.keeweapi.dto.insight.response.ReplyResponse;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.persistence.domain.insight.Comment;
+import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
 import ccc.keewedomain.service.insight.CommentDomainService;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +30,9 @@ public class InsightCommentQueryApiService {
     @Transactional(readOnly = true)
     public List<PreviewCommentResponse> getPreviewComments(Long insightId) {
         blockUtil.checkInsightWriter(insightId);
-        List<Comment> comments = commentDomainService.getComments(insightId, CursorPageable.of(Long.MAX_VALUE, 3L));
-        commentDomainService.findLatestCommentByWriter(SecurityUtil.getUser(), insightId)
+        User user = SecurityUtil.getUser();
+        List<Comment> comments = commentDomainService.getCommentsWithoutBlocked(insightId, CursorPageable.of(Long.MAX_VALUE, 3L), user.getId());
+        commentDomainService.findLatestCommentByWriter(user, insightId)
                 .ifPresent(myLatestComment -> {
                     comments.removeIf(comment -> comment.getId().equals(myLatestComment.getId()));
                     comments.add(0, myLatestComment);

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
@@ -34,6 +34,7 @@ public class InsightCommentQueryApiService {
         List<Comment> comments = commentDomainService.getCommentsWithoutBlocked(insightId, CursorPageable.of(Long.MAX_VALUE, 3L), user.getId());
         commentDomainService.findLatestCommentByWriter(user, insightId)
                 .ifPresent(myLatestComment -> {
+                    // note. 나의 최신 댓글이 기존의 리스트에서 존재하는 경우 제거. 나의 최신 댓글을 맨 앞에 추가.
                     comments.removeIf(comment -> comment.getId().equals(myLatestComment.getId()));
                     comments.add(0, myLatestComment);
                 });

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightDrawerQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightDrawerQueryApiService.java
@@ -1,7 +1,7 @@
 package ccc.keeweapi.service.insight.query;
 
 import ccc.keeweapi.component.InsightAssembler;
-import ccc.keeweapi.utils.BlockUtil;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.dto.insight.request.DrawerResponse;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.service.insight.DrawerDomainService;
@@ -17,7 +17,7 @@ public class InsightDrawerQueryApiService {
 
     private final DrawerDomainService drawerDomainService;
     private final InsightAssembler insightAssembler;
-    private final BlockUtil blockUtil;
+    private final BlockedResourceManager blockedResourceManager;
 
     @Transactional(readOnly = true)
     public List<DrawerResponse> getMyDrawers() {
@@ -30,7 +30,7 @@ public class InsightDrawerQueryApiService {
 
     @Transactional(readOnly = true)
     public List<DrawerResponse> getDrawers(Long userId) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         return drawerDomainService.findAllByUserId(userId).stream()
                 .map(insightAssembler::toDrawerResponse)
                 .collect(Collectors.toList());

--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightQueryApiService.java
@@ -2,13 +2,13 @@ package ccc.keeweapi.service.insight.query;
 
 import ccc.keeweapi.component.InsightAssembler;
 import ccc.keeweapi.component.ProfileAssembler;
-import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.dto.insight.response.ChallengeRecordResponse;
 import ccc.keeweapi.dto.insight.response.InsightAuthorAreaResponse;
 import ccc.keeweapi.dto.insight.response.InsightGetForHomeResponse;
 import ccc.keeweapi.dto.insight.response.InsightGetResponse;
 import ccc.keeweapi.dto.insight.response.InsightMyPageResponse;
 import ccc.keeweapi.dto.insight.response.InsightStatisticsResponse;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.exception.KeeweException;
@@ -19,9 +19,9 @@ import ccc.keewedomain.persistence.domain.insight.Insight;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
 import ccc.keewedomain.service.challenge.query.ChallengeParticipateQueryDomainService;
-import ccc.keewedomain.service.insight.CommentDomainService;
 import ccc.keewedomain.service.insight.ReactionDomainService;
 import ccc.keewedomain.service.insight.query.BookmarkQueryDomainService;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
 import ccc.keewedomain.service.insight.query.InsightQueryDomainService;
 import ccc.keewedomain.service.user.query.ProfileQueryDomainService;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +38,7 @@ public class InsightQueryApiService {
 
     private final InsightQueryDomainService insightQueryDomainService;
     private final ReactionDomainService reactionDomainService;
-    private final CommentDomainService commentDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
     private final BookmarkQueryDomainService bookmarkQueryDomainService;
     private final ProfileQueryDomainService profileQueryDomainService;
     private final InsightAssembler insightAssembler;
@@ -120,7 +120,7 @@ public class InsightQueryApiService {
         insightQueryDomainService.validateWriter(SecurityUtil.getUserId(), insightId);
         Long viewCount = insightQueryDomainService.getViewCount(insightId);
         Long reactionCount = reactionDomainService.getCurrentReactionAggregation(insightId).getAllReactionCount();
-        Long commentCount = commentDomainService.countByInsightId(insightId, SecurityUtil.getUserId());
+        Long commentCount = commentQueryDomainService.countByInsightId(insightId, SecurityUtil.getUserId());
         Long bookmarkCount = bookmarkQueryDomainService.countBookmarkByInsightId(insightId);
         Long shareCount = 0L; // FIXME 공유 카운팅 추가 시 변경 필요
         return insightAssembler.toInsightStatisticsResponse(viewCount, reactionCount, commentCount,bookmarkCount, shareCount);

--- a/keewe-api/src/main/java/ccc/keeweapi/service/notification/CommentNotificationProcessor.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/notification/CommentNotificationProcessor.java
@@ -5,14 +5,14 @@ import ccc.keewedomain.persistence.domain.insight.Comment;
 import ccc.keewedomain.persistence.domain.notification.Notification;
 import ccc.keewedomain.persistence.domain.notification.enums.NotificationCategory;
 import ccc.keewedomain.persistence.domain.notification.enums.NotificationContents;
-import ccc.keewedomain.service.insight.CommentDomainService;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class CommentNotificationProcessor implements NotificationProcessor {
-    private final CommentDomainService commentDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
 
     @Override
     public NotificationCategory getCategory() {
@@ -22,7 +22,7 @@ public class CommentNotificationProcessor implements NotificationProcessor {
     @Override
     public NotificationResponse process(Notification notification) {
         String commentId = notification.getReferenceId();
-        Comment comment = commentDomainService.getByIdOrElseThrow(Long.parseLong(commentId));
+        Comment comment = commentQueryDomainService.getByIdOrElseThrow(Long.parseLong(commentId));
         NotificationContents contents = notification.getContents();
         return NotificationResponse.of(
             notification.getId(),

--- a/keewe-api/src/main/java/ccc/keeweapi/service/notification/CommentReplyNotificationProcessor.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/notification/CommentReplyNotificationProcessor.java
@@ -5,14 +5,14 @@ import ccc.keewedomain.persistence.domain.insight.Comment;
 import ccc.keewedomain.persistence.domain.notification.Notification;
 import ccc.keewedomain.persistence.domain.notification.enums.NotificationCategory;
 import ccc.keewedomain.persistence.domain.notification.enums.NotificationContents;
-import ccc.keewedomain.service.insight.CommentDomainService;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class CommentReplyNotificationProcessor implements NotificationProcessor {
-    private final CommentDomainService commentDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
 
     @Override
     public NotificationCategory getCategory() {
@@ -22,7 +22,7 @@ public class CommentReplyNotificationProcessor implements NotificationProcessor 
     @Override
     public NotificationResponse process(Notification notification) {
         String commentReplyId = notification.getReferenceId();
-        Comment comment = commentDomainService.getByIdOrElseThrow(Long.parseLong(commentReplyId));
+        Comment comment = commentQueryDomainService.getByIdOrElseThrow(Long.parseLong(commentReplyId));
         NotificationContents contents = notification.getContents();
         return NotificationResponse.of(
             notification.getId(),

--- a/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
@@ -15,7 +15,7 @@ import ccc.keeweapi.dto.user.ProfileUpdateRequest;
 import ccc.keeweapi.dto.user.ProfileUpdateResponse;
 import ccc.keeweapi.dto.user.UnblockUserResponse;
 import ccc.keeweapi.dto.user.UploadProfilePhotoResponse;
-import ccc.keeweapi.utils.BlockUtil;
+import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.dto.user.FollowCheckDto;
 import ccc.keewedomain.persistence.domain.title.TitleAchievement;
@@ -49,7 +49,7 @@ public class ProfileApiService {
     private final ProfileAssembler profileAssembler;
     private final ProfileQueryDomainService profileQueryDomainService;
     private final ProfileCommandDomainService profileCommandDomainService;
-    private final BlockUtil blockUtil;
+    private final BlockedResourceManager blockedResourceManager;
 
     @Transactional
     public OnboardResponse onboard(OnboardRequest request) {
@@ -59,7 +59,7 @@ public class ProfileApiService {
 
     @Transactional
     public FollowToggleResponse toggleFollowership(Long userId) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         boolean following = profileCommandDomainService.toggleFollowership(profileAssembler.toFollowToggleDto(userId));
         return profileAssembler.toFollowToggleResponse(following);
     }
@@ -72,7 +72,7 @@ public class ProfileApiService {
 
     @Transactional(readOnly = true)
     public ProfileMyPageResponse getMyPageProfile(Long userId) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         User targetUser = userDomainService.getUserByIdWithInterests(userId);
         Long requestUserId = SecurityUtil.getUserId();
 
@@ -89,7 +89,7 @@ public class ProfileApiService {
 
     @Transactional(readOnly = true)
     public MyPageTitleResponse getMyPageTitles(Long userId) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         List<TitleAchievement> titleAchievements = profileQueryDomainService.getTitleAchievements(userId, MY_PAGE_TITLE_LIMIT);
         Long total = profileQueryDomainService.getAchievedTitleCount(userId);
 
@@ -98,7 +98,7 @@ public class ProfileApiService {
 
     @Transactional(readOnly = true)
     public AllAchievedTitleResponse getAllAchievedTitles(Long userId) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         List<TitleAchievement> titleAchievements = profileQueryDomainService.getTitleAchievements(userId, Integer.MAX_VALUE);
 
         return profileAssembler.toAllAchievedTitleResponse(SecurityUtil.getUser(), titleAchievements);
@@ -106,7 +106,7 @@ public class ProfileApiService {
 
     @Transactional(readOnly = true)
     public FollowUserListResponse getFollowers(Long userId, CursorPageable<LocalDateTime> cPage) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         List<Follow> follows = profileQueryDomainService.getFollowers(userId, cPage);
 
         return getFollowUser(follows, Follow::getFollower);
@@ -114,7 +114,7 @@ public class ProfileApiService {
 
     @Transactional(readOnly = true)
     public FollowUserListResponse getFollowees(Long userId, CursorPageable<LocalDateTime> cPage) {
-        blockUtil.checkUserId(userId);
+        blockedResourceManager.validateAccessibleUser(userId);
         List<Follow> follows = profileQueryDomainService.getFollowees(userId, cPage);
 
         return getFollowUser(follows, Follow::getFollowee);

--- a/keewe-api/src/main/java/ccc/keeweapi/utils/BlockedResourceManager.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/utils/BlockedResourceManager.java
@@ -15,33 +15,33 @@ import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
-public class BlockUtil {
+public class BlockedResourceManager {
     private final ProfileQueryDomainService profileQueryDomainService;
     private final InsightQueryDomainService insightQueryDomainService;
 
-    public void checkInsightWriter(Long insightId) {
+    public void validateAccessibleInsight(Long insightId) {
         Long writerId = insightQueryDomainService.getByIdWithWriter(insightId).getWriter().getId();
         validateUserIsBlocked(writerId);
     }
 
-    public void checkInsightWriter(InsightIdBlockRequest request) {
-        checkInsightWriter(request.getInsightId());
+    public void validateAccessibleInsight(InsightIdBlockRequest request) {
+        validateAccessibleInsight(request.getInsightId());
     }
 
-    public void checkUserId(Long userId) {
+    public void validateAccessibleUser(Long userId) {
         validateUserIsBlocked(userId);
     }
 
-    public void checkUserId(UserIdBlockRequest request) {
+    public void validateAccessibleUser(UserIdBlockRequest request) {
         validateUserIsBlocked(request.getUserId());
     }
 
-    public BlockFilteringResponse checkUserInResponse(BlockFilteringResponse response) {
+    public BlockFilteringResponse validateAccessibleUser(BlockFilteringResponse response) {
         validateUserIsBlocked(response.getUserId());
         return response;
     }
 
-    public <T extends BlockFilteringResponse> List<T> filterUserInResponses(List<T> responses) {
+    public <T extends BlockFilteringResponse> List<T> filterBlockedUsers(List<T> responses) {
         if(responses == null || responses.isEmpty()) {
             return responses;
         }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/CommentDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/CommentDomainService.java
@@ -95,6 +95,11 @@ public class CommentDomainService {
         return commentQueryRepository.findByInsightIdOrderByIdDesc(insightId, cPage);
     }
 
+    public List<Comment> getCommentsWithoutBlocked(Long insightId, CursorPageable<Long> cPage, Long userId) {
+        Set<Long> blockedUserIds = profileQueryDomainService.findBlockedUserIds(userId);
+        return commentQueryRepository.findByInsightIdOrderByIdDescWithoutBlocked(insightId, cPage, blockedUserIds);
+    }
+
     public Optional<Comment> findLatestCommentByWriter(User writer, Long insightId) {
         return commentQueryRepository.findLatestByWriterOrderById(writer, insightId);
     }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/command/CommentCommandDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/command/CommentCommandDomainService.java
@@ -1,0 +1,59 @@
+package ccc.keewedomain.service.insight.command;
+
+import ccc.keewecore.consts.KeeweRtnConsts;
+import ccc.keewecore.exception.KeeweException;
+import ccc.keewedomain.dto.insight.CommentCreateDto;
+import ccc.keewedomain.dto.insight.CommentDeleteDto;
+import ccc.keewedomain.persistence.domain.insight.Comment;
+import ccc.keewedomain.persistence.domain.insight.Insight;
+import ccc.keewedomain.persistence.domain.user.User;
+import ccc.keewedomain.persistence.repository.insight.CommentQueryRepository;
+import ccc.keewedomain.persistence.repository.insight.CommentRepository;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
+import ccc.keewedomain.service.insight.query.InsightQueryDomainService;
+import ccc.keewedomain.service.user.UserDomainService;
+import ccc.keewedomain.service.user.query.ProfileQueryDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCommandDomainService {
+    private final CommentRepository commentRepository;
+    private final InsightQueryDomainService insightQueryDomainService;
+    private final UserDomainService userDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
+
+    public Comment create(CommentCreateDto dto) {
+        Insight insight = insightQueryDomainService.getByIdOrElseThrow(dto.getInsightId());
+        User writer = userDomainService.getUserByIdOrElseThrow(dto.getWriterId());
+
+        Optional<Comment> optParent = commentQueryDomainService.findByIdAndInsightId(dto.getParentId(), dto.getInsightId());
+        optParent.ifPresent(this::validateHasNoParent);
+        Comment parent = optParent.orElse(null);
+
+        Comment comment = Comment.of(insight, writer, parent, dto.getContent());
+        return commentRepository.save(comment);
+    }
+
+    public Long delete(CommentDeleteDto dto) {
+        Comment comment = commentRepository.findById(dto.getCommentId()).orElseThrow(() -> {
+            throw new KeeweException(KeeweRtnConsts.ERR442);
+        });
+
+        if (!Objects.equals(comment.getWriter().getId(), dto.getUserId()))
+            throw new KeeweException(KeeweRtnConsts.ERR448);
+
+        comment.delete();
+        return comment.getId();
+    }
+
+    private void validateHasNoParent(Comment comment) {
+        if (comment.getParent() != null) {
+            throw new KeeweException(KeeweRtnConsts.ERR443);
+        }
+    }
+}

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/CommentQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/CommentQueryDomainService.java
@@ -1,16 +1,12 @@
-package ccc.keewedomain.service.insight;
+package ccc.keewedomain.service.insight.query;
 
 import ccc.keewecore.consts.KeeweRtnConsts;
 import ccc.keewecore.exception.KeeweException;
-import ccc.keewedomain.dto.insight.CommentCreateDto;
-import ccc.keewedomain.dto.insight.CommentDeleteDto;
 import ccc.keewedomain.persistence.domain.insight.Comment;
-import ccc.keewedomain.persistence.domain.insight.Insight;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.insight.CommentQueryRepository;
 import ccc.keewedomain.persistence.repository.insight.CommentRepository;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
-import ccc.keewedomain.service.insight.query.InsightQueryDomainService;
 import ccc.keewedomain.service.user.UserDomainService;
 import ccc.keewedomain.service.user.query.ProfileQueryDomainService;
 import lombok.RequiredArgsConstructor;
@@ -18,57 +14,23 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
-public class CommentDomainService {
-
+public class CommentQueryDomainService {
     private final CommentRepository commentRepository;
     private final CommentQueryRepository commentQueryRepository;
-    private final InsightQueryDomainService insightQueryDomainService;
-    private final UserDomainService userDomainService;
     private final ProfileQueryDomainService profileQueryDomainService;
-
-    public Comment create(CommentCreateDto dto) {
-        Insight insight = insightQueryDomainService.getByIdOrElseThrow(dto.getInsightId());
-        User writer = userDomainService.getUserByIdOrElseThrow(dto.getWriterId());
-
-        Optional<Comment> optParent = findByIdAndInsightId(dto.getParentId(), dto.getInsightId());
-        optParent.ifPresent(this::validateHasNoParent);
-        Comment parent = optParent.orElse(null);
-
-        Comment comment = Comment.of(insight, writer, parent, dto.getContent());
-        return commentRepository.save(comment);
-    }
 
     public Comment getByIdOrElseThrow(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new KeeweException(KeeweRtnConsts.ERR481));
     }
 
-    public Long delete(CommentDeleteDto dto) {
-        Comment comment = commentRepository.findById(dto.getCommentId()).orElseThrow(() -> {
-            throw new KeeweException(KeeweRtnConsts.ERR442);
-        });
-
-        if (!Objects.equals(comment.getWriter().getId(), dto.getUserId()))
-            throw new KeeweException(KeeweRtnConsts.ERR448);
-
-        comment.delete();
-        return comment.getId();
-    }
-
-    private Optional<Comment> findByIdAndInsightId(Long id, Long insightId) {
+    public Optional<Comment> findByIdAndInsightId(Long id, Long insightId) {
         return commentRepository.findByIdAndInsightId(id, insightId);
-    }
-
-    private void validateHasNoParent(Comment comment) {
-        if (comment.getParent() != null) {
-            throw new KeeweException(KeeweRtnConsts.ERR443);
-        }
     }
 
     public Long countByInsightId(Long insightId, Long userId) {

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/report/CommentReportDomainServiceImpl.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/report/CommentReportDomainServiceImpl.java
@@ -7,16 +7,17 @@ import ccc.keewedomain.persistence.domain.insight.enums.ReportTarget;
 import ccc.keewedomain.persistence.domain.report.Report;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.report.ReportRepository;
-import ccc.keewedomain.service.insight.CommentDomainService;
+import ccc.keewedomain.service.insight.query.CommentQueryDomainService;
 import ccc.keewedomain.service.user.UserDomainService;
 import ccc.keeweinfra.service.notification.SlackNotiService;
 import ccc.keeweinfra.vo.Attachment;
 import ccc.keeweinfra.vo.Field;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class CommentReportDomainServiceImpl implements ReportDomainService {
     private final UserDomainService userDomainService;
     private final SlackNotiService slackNotiService;
-    private final CommentDomainService commentDomainService;
+    private final CommentQueryDomainService commentQueryDomainService;
     private final ReportRepository reportRepository;
 
     @Value("${spring.config.activate.on-profile}")
@@ -33,7 +34,7 @@ public class CommentReportDomainServiceImpl implements ReportDomainService {
     @Override
     public Report save(ReportCreateDto reportCreateDto) {
         User reporter = userDomainService.getUserByIdOrElseThrow(reportCreateDto.getUserId());
-        Comment comment = commentDomainService.getByIdOrElseThrow(reportCreateDto.getTargetId());
+        Comment comment = commentQueryDomainService.getByIdOrElseThrow(reportCreateDto.getTargetId());
 
         Report report = Report.of(reporter,
                 reportCreateDto.getReportTarget(),

--- a/keewe-domain/src/test/java/ccc/keewedomain/service/insight/CommentDomainServiceTest.java
+++ b/keewe-domain/src/test/java/ccc/keewedomain/service/insight/CommentDomainServiceTest.java
@@ -13,6 +13,7 @@ import ccc.keewedomain.persistence.domain.user.enums.VendorType;
 import ccc.keewedomain.persistence.repository.insight.CommentRepository;
 import ccc.keewedomain.persistence.repository.insight.InsightRepository;
 import ccc.keewedomain.persistence.repository.user.UserRepository;
+import ccc.keewedomain.service.insight.command.CommentCommandDomainService;
 import ccc.keewedomain.utils.DatabaseCleaner;
 import ccc.keeweinfra.KeeweInfraApplication;
 import org.junit.jupiter.api.AfterEach;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class CommentDomainServiceTest {
 
     @Autowired
-    CommentDomainService commentDomainService;
+    CommentCommandDomainService commentCommandDomainService;
 
     @Autowired
     CommentRepository commentRepository;
@@ -71,7 +72,7 @@ public class CommentDomainServiceTest {
         CommentCreateDto commentCreateDto = CommentCreateDto.of(user.getId(), insight.getId(), null, "내용");
 
         //when
-        Comment createdComment = commentDomainService.create(commentCreateDto);
+        Comment createdComment = commentCommandDomainService.create(commentCreateDto);
         Comment savedComment = commentRepository.findById(createdComment.getId()).get();
 
         //then
@@ -90,7 +91,7 @@ public class CommentDomainServiceTest {
         CommentCreateDto replyCreateDto = CommentCreateDto.of(user.getId(), insight.getId(), comment.getId(), "내용");
 
         //when
-        Comment reply = commentDomainService.create(replyCreateDto);
+        Comment reply = commentCommandDomainService.create(replyCreateDto);
         Comment savedReply = commentRepository.findById(reply.getId()).get();
 
         //then
@@ -110,7 +111,7 @@ public class CommentDomainServiceTest {
         CommentCreateDto replyDto = CommentCreateDto.of(user.getId(), insight.getId(), reply1.getId(), "답글에 답글 달기");
 
         //when, then
-        assertThatThrownBy(() -> commentDomainService.create(replyDto))
+        assertThatThrownBy(() -> commentCommandDomainService.create(replyDto))
                 .isExactlyInstanceOf(KeeweException.class)
                 .hasMessage(KeeweRtnConsts.ERR443.getDescription());
     }
@@ -123,7 +124,7 @@ public class CommentDomainServiceTest {
         CommentCreateDto commentCreateDto = CommentCreateDto.of(user.getId(), invalidInsightId, null, "내용");
 
         //when
-        assertThatThrownBy(() -> commentDomainService.create(commentCreateDto))
+        assertThatThrownBy(() -> commentCommandDomainService.create(commentCreateDto))
                 .isExactlyInstanceOf(KeeweException.class)
                 .hasMessage(KeeweRtnConsts.ERR445.getDescription());
     }


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- close #297
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->


- 미리보기에서 차단된 유저의 댓글을 넘기고 다음 순서에 해당하는 댓글을 노출
- 네이밍 수정 `BlockUtil` -> `BlockedResourceManager`, 메서드 이름 포함
