### PR TITLE
[Fix] 댓글 조회 API 쿼리에서 차단 필터링 적용

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightCommentQueryApiService.java
@@ -48,10 +48,11 @@ public class InsightCommentQueryApiService {
 
     @Transactional(readOnly = true)
     public List<CommentResponse> getCommentsWithFirstReply(Long insightId, CursorPageable<Long> cPage) {
+        Long userId = SecurityUtil.getUserId();
         blockedResourceManager.validateAccessibleInsight(insightId);
         List<Comment> comments = commentQueryDomainService.getComments(insightId, cPage);
-        Map<Long, Comment> firstReplyPerParentId = commentQueryDomainService.getFirstReplies(comments);
-        Map<Long, Long> replyNumberPerParentId = commentQueryDomainService.getReplyNumbers(comments);
+        Map<Long, Comment> firstReplyPerParentId = commentQueryDomainService.getFirstReplies(comments, userId);
+        Map<Long, Long> replyNumberPerParentId = commentQueryDomainService.getReplyNumbers(comments, userId);
 
         List<CommentResponse> responses = comments.stream()
                 .map(comment -> commentAssembler.toCommentResponse(

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/CommentQueryDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/insight/query/CommentQueryDomainService.java
@@ -7,7 +7,6 @@ import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.insight.CommentQueryRepository;
 import ccc.keewedomain.persistence.repository.insight.CommentRepository;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
-import ccc.keewedomain.service.user.UserDomainService;
 import ccc.keewedomain.service.user.query.ProfileQueryDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,8 +48,9 @@ public class CommentQueryDomainService {
         return commentCount - blockedUserCommentIds.size() - replyOnBlockedCommentCount + dupBlockedReplyCount;
     }
 
-    public Map<Long, Long> getReplyNumbers(List<Comment> parents) {
-        return commentQueryRepository.getReplyNumbers(parents);
+    public Map<Long, Long> getReplyNumbers(List<Comment> parents, Long userId) {
+        Set<Long> blockedUserIds = profileQueryDomainService.findBlockedUserIds(userId);
+        return commentQueryRepository.getReplyNumbers(parents, blockedUserIds);
     }
 
     public List<Comment> getComments(Long insightId, CursorPageable<Long> cPage) {
@@ -66,8 +66,9 @@ public class CommentQueryDomainService {
         return commentQueryRepository.findLatestByWriterOrderById(writer, insightId);
     }
 
-    public Map<Long, Comment> getFirstReplies(List<Comment> parents) {
-        return commentQueryRepository.findFirstRepliesWithWriter(parents);
+    public Map<Long, Comment> getFirstReplies(List<Comment> parents, Long userId) {
+        Set<Long> blockedUserIds = profileQueryDomainService.findBlockedUserIds(userId);
+        return commentQueryRepository.findFirstRepliesWithWriter(parents, blockedUserIds);
     }
 
     public List<Comment> getReplies(Long parentId, CursorPageable<Long> cPage) {


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- close #298 
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->


- 댓글의 첫 번째 답글이 차단된 유저의 것인 경우 다음 순서의 답글을 노출
- 댓글의 답글 수 조회 시 차단된 유저의 답글은 제외
- 쿼리에서 필터링을 적용해서 구현했어요
