### PR TITLE
[Fix] 챌린지 참가 시 챌린지의 deleted 상태를 변경해요

### DIFF
--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/Challenge.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/challenge/Challenge.java
@@ -61,6 +61,7 @@ public class Challenge extends BaseTimeEntity {
                 insightPerWeek,
                 duration);
         getParticipationList().add(participation);
+        this.deleted = false;
         return participation;
     }
 


### PR DESCRIPTION
현재 종료된 챌린지를 클릭하면 상세 정보에서 챌린지 참여가 가능한데요.

삭제된 챌린지를 참가처리하면, 정상 참여가 되는데 챌린지는 삭제 상태 그대로라 목록에 노출되지 않는 문제가 있어요

위 문제를 해소하는 PR이에요