### PR TITLE
[Fix] 최초 회원가입 타이틀 획득 버그 수정

### DIFF
--- a/keewe-api/http/http-client.env.json
+++ b/keewe-api/http/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "keewe-api-local": {
+    "host": "http://localhost:8080"
+  },
+  "keewe-api-dev": {
+    "host": "https://api-keewe.com/"
+  }
+}

--- a/keewe-api/http/signup.http
+++ b/keewe-api/http/signup.http
@@ -1,0 +1,2 @@
+// note. 로컬 가상 회원가입
+GET {{host}}/api/v1/user/virtual?code=test

--- a/keewe-api/src/main/java/ccc/keeweapi/controller/api/user/UserSignUpController.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/controller/api/user/UserSignUpController.java
@@ -6,7 +6,13 @@ import ccc.keewecore.aop.annotations.LocalOnlyApi;
 import ccc.keewedomain.persistence.domain.user.enums.VendorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/user")
@@ -36,6 +42,12 @@ public class UserSignUpController {
     @LocalOnlyApi
     public ApiResponse<?> getToken(@PathVariable Long userId) {
         return ApiResponse.ok(userService.getToken(userId));
+    }
+
+    @GetMapping("/virtual")
+    @LocalOnlyApi
+    public ApiResponse<?> signUpWithVirtualVendor(@RequestParam String code) {
+        return ApiResponse.ok(userService.signupWithOauth(code, VendorType.VIRTUAL));
     }
 
     @PutMapping("/withdraw")

--- a/keewe-api/src/main/java/ccc/keeweapi/service/user/UserApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/user/UserApiService.java
@@ -39,7 +39,6 @@ public class UserApiService {
     private final ProfileCommandDomainService profileCommandDomainService;
     private final ChallengeCommandDomainService challengeCommandDomainService;
 
-    @Transactional
     @FLogging
     public <T extends OauthResponse> UserSignUpResponse signupWithOauth(String code, VendorType vendorType) {
         T account = userDomainService.getOauthProfile(code, vendorType);
@@ -56,7 +55,7 @@ public class UserApiService {
                 , KeeweStringUtils.getOrDefault(account.getEmail(), "")
         );
 
-        afterTheFirstSignUp(user);
+        this.afterTheFirstSignUp(user);
         log.info("[UAS::signupWithOauth] 회원가입 완료 - email({})", account.getEmail());
         return userAssembler.toUserSignUpResponse(user, false, getToken(user.getId()));
     }

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/VendorType.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/domain/user/enums/VendorType.java
@@ -4,5 +4,6 @@ public enum VendorType {
     KAKAO,
     NAVER,
     GOOGLE,
-    APPLE
+    APPLE,
+    VIRTUAL,
 }

--- a/keewe-domain/src/main/java/ccc/keewedomain/service/user/UserDomainService.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/service/user/UserDomainService.java
@@ -11,6 +11,7 @@ import ccc.keeweinfra.dto.GoogleProfileResponse;
 import ccc.keeweinfra.dto.KakaoProfileResponse;
 import ccc.keeweinfra.dto.NaverProfileResponse;
 import ccc.keeweinfra.dto.OauthResponse;
+import ccc.keeweinfra.dto.VirtualProfileResponse;
 import ccc.keeweinfra.service.oauth.GoogleInfraService;
 import ccc.keeweinfra.service.oauth.KakaoInfraService;
 import ccc.keeweinfra.service.oauth.NaverInfraService;
@@ -38,6 +39,8 @@ public class UserDomainService {
                 return (T) getNaverProfile(code);
             case GOOGLE:
                 return (T) getGoogleProfile(code);
+            case VIRTUAL:
+                return (T) getVirtualProfile(code);
             default:
                 throw new KeeweException(KeeweRtnConsts.ERR504);
         }
@@ -86,4 +89,7 @@ public class UserDomainService {
         }
     }
 
+    private VirtualProfileResponse getVirtualProfile(String code) {
+        return new VirtualProfileResponse();
+    }
 }

--- a/keewe-infra/src/main/java/ccc/keeweinfra/dto/VirtualProfileResponse.java
+++ b/keewe-infra/src/main/java/ccc/keeweinfra/dto/VirtualProfileResponse.java
@@ -1,0 +1,17 @@
+package ccc.keeweinfra.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class VirtualProfileResponse implements OauthResponse {
+    @Override
+    public String getId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return null;
+    }
+}


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- 회원가입 타이틀 획득 버그를 수정해요.
## 작업 내용 
<!-- PR에서 작업한 내용을 상세하게 적어주세요. -->

- Tx Commit되는 시점에 유저 정보가 데이터베이스에 저장되기때문에, 타이틀 획득 이벤트를 발행하고 statistics 모듈에서 타이틀 획득처리할 때 유저 정보가 없을 수 있어요.
- Tx가 필요하지 않다고도 판단되어서, 제거하였고 JPA 쓰기 지연이 작동하지 않도록 수정했어요


