### PR TITLE
[Fix] 마이페이지 응답에 참여중인 ChallengeId 추가

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/component/ProfileAssembler.java
@@ -4,6 +4,7 @@ import ccc.keeweapi.dto.insight.response.ProfileVisitFromInsightCountResponse;
 import ccc.keeweapi.dto.user.*;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewedomain.dto.user.*;
+import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.common.Interest;
 import ccc.keewedomain.persistence.domain.title.Title;
 import ccc.keewedomain.persistence.domain.title.TitleAchievement;
@@ -49,7 +50,9 @@ public class ProfileAssembler {
         );
     }
 
-    public ProfileMyPageResponse toProfileMyPageResponse(User user, Boolean isFollowing, Long followerCount, Long followingCount, String challengeName) {
+    public ProfileMyPageResponse toProfileMyPageResponse(User user, Boolean isFollowing, Long followerCount, Long followingCount, Challenge challenge) {
+        Long challengeId = challenge != null ? challenge.getId() : null;
+        String challengeName = challenge != null ? challenge.getName() : null;
         return ProfileMyPageResponse.of(
                 user.getNickname(),
                 user.getProfilePhotoURL(),
@@ -61,7 +64,8 @@ public class ProfileAssembler {
                 isFollowing,
                 followerCount,
                 followingCount,
-                challengeName
+                challengeName,
+                challengeId
         );
     }
 

--- a/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/dto/user/ProfileMyPageResponse.java
@@ -18,4 +18,5 @@ public class ProfileMyPageResponse {
     private Long followerCount;
     private Long followingCount;
     private String challengeName;
+    private Long challengeId;
 }

--- a/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/user/ProfileApiService.java
@@ -21,6 +21,8 @@ import ccc.keeweapi.utils.BlockedResourceManager;
 import ccc.keeweapi.utils.SecurityUtil;
 import ccc.keewecore.utils.ListUtils;
 import ccc.keewedomain.dto.user.FollowCheckDto;
+import ccc.keewedomain.persistence.domain.challenge.Challenge;
+import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.title.TitleAchievement;
 import ccc.keewedomain.persistence.domain.user.Block;
 import ccc.keewedomain.persistence.domain.user.Follow;
@@ -85,12 +87,12 @@ public class ProfileApiService {
         Long followerCount = profileQueryDomainService.getFollowerCount(targetUser);
         Long followingCount = profileQueryDomainService.getFollowingCount(targetUser);
 
-        String challengeName = challengeParticipateQueryDomainService.findCurrentParticipationByUserId(userId)
-                .map(challengeParticipation -> challengeParticipation.getChallenge().getName())
+        Challenge challenge = challengeParticipateQueryDomainService.findCurrentParticipationByUserId(userId)
+                .map(ChallengeParticipation::getChallenge)
                 .orElse(null);
 
         afterGetMyProfile(userId, insightId);
-        return profileAssembler.toProfileMyPageResponse(targetUser, isFollowing, followerCount, followingCount, challengeName);
+        return profileAssembler.toProfileMyPageResponse(targetUser, isFollowing, followerCount, followingCount, challenge);
     }
 
     @Transactional(readOnly = true)

--- a/keewe-api/src/test/java/ccc/keeweapi/controller/api/user/UserProfileControllerTest.java
+++ b/keewe-api/src/test/java/ccc/keeweapi/controller/api/user/UserProfileControllerTest.java
@@ -67,7 +67,6 @@ public class UserProfileControllerTest extends ApiDocumentationTest {
         onboardRequest
                 .put("nickname", nickname)
                 .put("interests", jsonArray);
-        System.out.println("onboardRequest.toString() = " + onboardRequest.toString());
         when(profileApiService.onboard(any())).thenReturn(
                 OnboardResponse.of(userId, nickname, interests.stream().map(Interest::of).collect(Collectors.toList())));
 
@@ -110,7 +109,8 @@ public class UserProfileControllerTest extends ApiDocumentationTest {
                         false,
                         342L,
                         55231L,
-                        "출근하기"
+                        "출근하기",
+                        1L
                 )
         );
 
@@ -143,7 +143,8 @@ public class UserProfileControllerTest extends ApiDocumentationTest {
                                 fieldWithPath("data.follow").description("팔로잉 여부 (true: 팔로잉 상태, false: 언팔로잉 상태)"),
                                 fieldWithPath("data.followerCount").description("팔로워 수"),
                                 fieldWithPath("data.followingCount").description("팔로우 하는 수"),
-                                fieldWithPath("data.challengeName").description("진행중인 챌린지 이름"))
+                                fieldWithPath("data.challengeName").description("진행중인 챌린지 이름"),
+                                fieldWithPath("data.challengeId").description("진행중인 챌린지 ID"))
                         .tag("UserProfile")
                         .build()
         )));


### PR DESCRIPTION
마이페이지에서 챌린지 상세로 이동할 수 있도록 ID를 내려줘요
