### PR TITLE
[Fix] 북마크 인사이트 목록 조회 버그 수정

### DIFF
--- a/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightQueryApiService.java
+++ b/keewe-api/src/main/java/ccc/keeweapi/service/insight/query/InsightQueryApiService.java
@@ -80,7 +80,6 @@ public class InsightQueryApiService {
         return blockedResourceManager.filterBlockedUsers(responses);
     }
 
-    @Transactional(readOnly = true)
     public List<InsightGetForBookmarkedResponse> getInsightForBookmark(CursorPageable<LocalDateTime> cPage) {
         List<InsightGetForBookmarkedResponse> responses = insightQueryDomainService.getInsightForBookmark(SecurityUtil.getUser(), cPage).stream()
                 .map(insightAssembler::toInsightGetForBookmarkedResponse)

--- a/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
+++ b/keewe-domain/src/main/java/ccc/keewedomain/persistence/repository/insight/InsightQueryRepository.java
@@ -14,7 +14,6 @@ import static ccc.keewedomain.persistence.domain.user.QUser.user;
 import ccc.keewedomain.persistence.domain.challenge.Challenge;
 import ccc.keewedomain.persistence.domain.challenge.ChallengeParticipation;
 import ccc.keewedomain.persistence.domain.insight.Insight;
-import ccc.keewedomain.persistence.domain.title.QTitle;
 import ccc.keewedomain.persistence.domain.user.QUser;
 import ccc.keewedomain.persistence.domain.user.User;
 import ccc.keewedomain.persistence.repository.utils.CursorPageable;
@@ -26,13 +25,12 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -209,11 +207,13 @@ public class InsightQueryRepository {
                 .limit(cPage.getLimit())
                 .fetch();
 
-        return result.stream().collect(Collectors.toMap(
-                tuple -> tuple.get(0, Insight.class),
-                tuple -> tuple.get(1, LocalDateTime.class),
-                (oldValue, newValue) -> oldValue
-        ));
+        return result.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Insight.class),
+                        tuple -> tuple.get(1, LocalDateTime.class),
+                        (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new // note. LinkedHashMap 사용하여 순서 보장
+                ));
     }
 
     public List<Insight> findByChallenge(Challenge challenge, CursorPageable<Long> cPage, Long writerId) {


### PR DESCRIPTION
## 관련 Issue
<!-- 관련 이슈를 함께 #200 과 같이 적어주세요 -->
<!-- PR과 함께 close 하려면 close 키워드를 붙여주세요. -->

- 북마크 인사이트 시 아래 버그를 수정합니다.

1. 인사이트 데이터 순서 보장 -> List<Tuple>을 Map으로 변환하는과정에서 순서 보장 불가한 부분 수정
2. parallelStream 내에서 Jpa Entity Graph (연관관계 객체 탐색) 조회를 타게되면, 문제가 있네요.
-> 레디스 조회가 병렬 처리의 목적이므로 레디스 조회만 병렬처리로 별도 분리하고, Jpa stream 처리는 순차 처리로 수정합니다.

